### PR TITLE
Fix bug#1371: namespace insertion fails in some cases

### DIFF
--- a/releasetools/xslns-build
+++ b/releasetools/xslns-build
@@ -249,7 +249,7 @@ sub nsfilter {
   
   # Add the docbook5 namespace declaration to root element
   
-  s|(xmlns:xsl\s*=\s*"http://www.w3.org/1999/XSL/Transform"(?!>))(\s*\n?)(\s*)|$1$2$3xmlns:d="http://docbook.org/ns/docbook"\n$3|s;
+  s|([ \t]*)(xmlns:xsl\s*=\s*"http://www.w3.org/1999/XSL/Transform")|$1$2\n$1xmlns:d="http://docbook.org/ns/docbook"|s;
   
   # Add namespace d to exclude-result-prefixes
   


### PR DESCRIPTION
When you have `<xsl:stylesheet xmlns:xsl="...">`, the script would fail to do its job because immediately after the final quote, `"`, the tag was closed with `>`.
Of course, that is completely valid XML, so it should not trip up the script.
