### PR TITLE
Respect make.clean.html in step/title

### DIFF
--- a/xsl/epub3/docbook-epub.css.xml
+++ b/xsl/epub3/docbook-epub.css.xml
@@ -95,6 +95,16 @@ div.sidebar-title {
 /********************************/
 
 /********************************/
+/* start of styles in lists.xsl */
+
+.step-title {
+  font-weight: bold;
+}
+
+/* end of styles in lists.xsl */
+/********************************/
+
+/********************************/
 /* start of styles in verbatim.xsl */
 
 div.programlisting {

--- a/xsl/html/docbook.css.xml
+++ b/xsl/html/docbook.css.xml
@@ -82,6 +82,16 @@ div.sidebar-title {
 /********************************/
 
 /********************************/
+/* start of styles in lists.xsl */
+
+.step-title {
+  font-weight: bold;
+}
+
+/* end of styles in lists.xsl */
+/********************************/
+
+/********************************/
 /* start of styles in verbatim.xsl */
 
 div.programlisting {

--- a/xsl/html/lists.xsl
+++ b/xsl/html/lists.xsl
@@ -915,9 +915,18 @@
 <xsl:template match="d:step/d:title">
   <p>
     <xsl:call-template name="common.html.attributes"/>
-    <b>
-      <xsl:apply-templates/>
-    </b>
+    <xsl:choose>
+      <xsl:when test="$make.clean.html != 0">
+	<span class="step-title">
+	  <xsl:apply-templates/>
+	</span>
+      </xsl:when>
+      <xsl:otherwise>
+	<b>
+	  <xsl:apply-templates/>
+	</b>
+      </xsl:otherwise>
+    </xsl:choose>
   </p>
 </xsl:template>
 

--- a/xsl/xhtml5/docbook.css.xml
+++ b/xsl/xhtml5/docbook.css.xml
@@ -82,6 +82,16 @@ div.sidebar-title {
 /********************************/
 
 /********************************/
+/* start of styles in lists.xsl */
+
+.step-title {
+  font-weight: bold;
+}
+
+/* end of styles in lists.xsl */
+/********************************/
+
+/********************************/
 /* start of styles in verbatim.xsl */
 
 div.programlisting {


### PR DESCRIPTION
Elsewhere, `make.clean.html` wraps content in a `<div>` or `<span>` rather than using `<b>` directly.  But this was not done for `step/title`, so add that.