### PR TITLE
add lang specific characters to pt_BR alphabet

### DIFF
--- a/gentext/locale/pt_br.xml
+++ b/gentext/locale/pt_br.xml
@@ -201,8 +201,8 @@
 <gentext key="index symbols" text="Símbolos"/> 
 <gentext key="writing-mode" text="lr-tb"/>
 
-<gentext key="lowercase.alpha" text="abcdefghijklmnopqrstuvwxyz"/> 
-<gentext key="uppercase.alpha" text="ABCDEFGHIJKLMNOPQRSTUVWXYZ"/> 
+<gentext key="lowercase.alpha" text="aáàâãbcçdeéêfghiíjklmnoóôõpqrstuúüvwxyz"/>
+<gentext key="uppercase.alpha" text="AÁÀÂÃBCÇDEÉÊFGHIÍJKLMNOÓÔÕPQRSTUÚÜVWXYZ"/>
 
 <dingbat key="startquote"		text="&#x201C;"/>
 <dingbat key="endquote"			text="&#x201D;"/>


### PR DESCRIPTION
Similarly to https://github.com/docbook/xslt10-stylesheets/commit/e9f52863d4ec4dc8f372f4438ee37d42f960f972 , lang specific chars should be updated in pt_br.xml as well. Charset used used from https://bugzilla.redhat.com/show_bug.cgi?id=803828 original report. "caution/chapter" strings seems to be correct in Brazilian locale xml.