### PR TITLE
Get all metadata from resource referenced by merge element

### DIFF
--- a/xsl/assembly/assemble.xsl
+++ b/xsl/assembly/assemble.xsl
@@ -551,16 +551,17 @@
     </xsl:if>
   </xsl:variable>
 
-  <xsl:variable name="merge.ref.info" 
-                select="exsl:node-set($merge.ref.content)//d:info[1]"/>
+  <!-- Copy all metadata from merge.ref.content to a single node-set -->
+  <xsl:variable name="merge.ref.metadata">
+    <xsl:copy-of select="exsl:node-set($merge.ref.content)/*/d:info[1]/@*"/>
+    <xsl:copy-of select="exsl:node-set($merge.ref.content)/*/d:title[1]"/>
+    <xsl:copy-of select="exsl:node-set($merge.ref.content)/*/d:titleabbrev[1]"/>
+    <xsl:copy-of select="exsl:node-set($merge.ref.content)/*/d:subtitle[1]"/>
+    <xsl:copy-of select="exsl:node-set($merge.ref.content)/*/d:info[1]/node()"/>
+  </xsl:variable>
 
-  <xsl:if test="$merge.element/@resourceref and not($merge.ref.info)">
-    <xsl:message terminate="yes">
-      <xsl:text>ERROR: merge element with resourceref '</xsl:text>
-      <xsl:value-of select="$merge.element/@resourceref"/>
-      <xsl:text>' must point to something with an info element.'</xsl:text>
-    </xsl:message>
-  </xsl:if>
+  <xsl:variable name="merge.ref.info"
+                select="exsl:node-set($merge.ref.metadata)"/>
 
   <xsl:variable name="omittitles.boolean">
     <xsl:choose>


### PR DESCRIPTION
When a <merge> element uses a resourceref attribute to point to a
resource, the stylesheet collects the <title>, <titleabbrev> and
<subtitle> elements from the top level of the resource (if they
exist), concatenates them with the content of the <info> element
from the top level of the resource (if that exists), and outputs
them all to the <info> element in the assembled document.

The warning that the referenced file must contain an info element
is removed.