### PR TITLE
Omit info from resource when omittitles set

### DIFF
--- a/xsl/assembly/assemble.xsl
+++ b/xsl/assembly/assemble.xsl
@@ -45,11 +45,9 @@
 
 <!-- handle omittitles, but only top level title of resource -->
 <xsl:template match="/*/d:title
-                   | /*/d:info/d:title
                    | /*/d:subtitle
-                   | /*/d:info/d:subtitle
                    | /*/d:titleabbrev
-                   | /*/d:info/d:titleabbrev"
+                   | /*/d:info"
               mode="copycontent">
   <xsl:param name="omittitles"/>
 


### PR DESCRIPTION
When omittitles is set for a module, the stylesheet omits the
entire <info> element from the resource, not just the <title>,
<titleabbrev>, and <subtitle> elements.