### PR TITLE
Only set target.database.filename if target.database.document is set

### DIFF
--- a/xsl/common/olink.xsl
+++ b/xsl/common/olink.xsl
@@ -63,6 +63,7 @@
   <xsl:variable name="target.database.filename">
     <xsl:choose>
       <xsl:when test="$xml.base != '' and
+                   not($target.database.document = '') and
                    not(starts-with($target.database.document, 'file:/')) and
                    not(starts-with($target.database.document, '/'))">
         <xsl:call-template name="systemIdToBaseURI">


### PR DESCRIPTION
Addressing https://github.com/docbook/xslt10-stylesheets/issues/47 by checking to see if target.database.document is set.

@bobstayton please review. 