### PR TITLE
Fix Muenchian-grouping and other uses of [&scope;]

### DIFF
--- a/xsl/fo/autoidx.xsl
+++ b/xsl/fo/autoidx.xsl
@@ -109,11 +109,11 @@
 
   <xsl:variable name="terms"
                 select="//d:indexterm
-                        [count(.|key('letter',
+                        [generate-id() = generate-id(key('letter',
                           translate(substring(&primary;, 1, 1),
                              &lowercase;,
                              &uppercase;))
-                          [&scope;][1]) = 1
+                          [&scope;])
                           and not(@class = 'endofrange')]"/>
 
   <xsl:variable name="alphabetical"
@@ -135,8 +135,8 @@
       </xsl:call-template>
 
       <fo:block>
-        <xsl:apply-templates select="$others[count(.|key('primary',
-                                     &primary;)[&scope;][1]) = 1]"
+        <xsl:apply-templates select="$others[generate-id() = generate-id(key('primary',
+                                     &primary;)[&scope;])]"
                              mode="index-symbol-div">
           <xsl:with-param name="scope" select="$scope"/>
           <xsl:with-param name="role" select="$role"/>
@@ -147,10 +147,10 @@
       </fo:block>
     </xsl:if>
 
-    <xsl:apply-templates select="$alphabetical[count(.|key('letter',
+    <xsl:apply-templates select="$alphabetical[generate-id() = generate-id(key('letter',
                                  translate(substring(&primary;, 1, 1),
                                            &lowercase;,&uppercase;))
-                                           [&scope;][1]) = 1]"
+                                           [&scope;])]"
                          mode="index-div-basic">
       <xsl:with-param name="scope" select="$scope"/>
       <xsl:with-param name="role" select="$role"/>
@@ -224,7 +224,7 @@
                          &lowercase;,&uppercase;)"/>
 
   <xsl:if test="key('letter', $key)[&scope;]
-                [count(.|key('primary', &primary;)[&scope;][1]) = 1]">
+                [generate-id() = generate-id(key('primary', &primary;)[&scope;])]">
     <fo:block>
       <xsl:if test="contains(concat(&lowercase;, &uppercase;), $key)">
         <xsl:call-template name="indexdiv.title">
@@ -235,8 +235,8 @@
       </xsl:if>
       <fo:block xsl:use-attribute-sets="index.entry.properties">
         <xsl:apply-templates select="key('letter', $key)[&scope;]
-                                     [count(.|key('primary', &primary;)
-                                     [&scope;][1])=1]"
+                                     [generate-id() = generate-id(key('primary', &primary;)
+                                     [&scope;])]"
                              mode="index-primary">
           <xsl:sort select="translate(&primary;, &lowercase;, &uppercase;)"/>
           <xsl:with-param name="scope" select="$scope"/>
@@ -257,7 +257,7 @@
                 select="translate(substring(&primary;, 1, 1),&lowercase;,&uppercase;)"/>
 
   <fo:block xsl:use-attribute-sets="index.entry.properties">
-    <xsl:apply-templates select="key('letter', $key)[&scope;][count(.|key('primary', &primary;)[&scope;][1]) = 1]"
+    <xsl:apply-templates select="key('letter', $key)[&scope;][generate-id() = generate-id(key('primary', &primary;)[&scope;])]"
                          mode="index-primary">
       <xsl:with-param name="scope" select="$scope"/>
       <xsl:with-param name="role" select="$role"/>
@@ -348,7 +348,7 @@
     </xsl:choose>
 
     <xsl:if test="$refs[not(d:secondary)]/*[self::d:see]">
-      <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see', concat(&primary;, &sep;, &sep;, &sep;, d:see))[&scope;][1])]"
+      <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see', concat(&primary;, &sep;, &sep;, &sep;, d:see))[&scope;])]"
                            mode="index-see">
          <xsl:with-param name="scope" select="$scope"/>
          <xsl:with-param name="role" select="$role"/>
@@ -361,14 +361,14 @@
 
   <xsl:if test="$refs/d:secondary or $refs[not(d:secondary)]/*[self::d:seealso]">
     <fo:block start-indent="1pc">
-      <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see-also', concat(&primary;, &sep;, &sep;, &sep;, d:seealso))[&scope;][1])]"
+      <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see-also', concat(&primary;, &sep;, &sep;, &sep;, d:seealso))[&scope;])]"
                            mode="index-seealso">
          <xsl:with-param name="scope" select="$scope"/>
          <xsl:with-param name="role" select="$role"/>
          <xsl:with-param name="type" select="$type"/>
          <xsl:sort select="translate(d:seealso, &lowercase;, &uppercase;)"/>
       </xsl:apply-templates>
-      <xsl:apply-templates select="$refs[d:secondary and count(.|key('secondary', concat($key, &sep;, &secondary;))[&scope;][1]) = 1]"
+      <xsl:apply-templates select="$refs[d:secondary and generate-id() = generate-id(key('secondary', concat($key, &sep;, &secondary;))[&scope;])]"
                            mode="index-secondary">
        <xsl:with-param name="scope" select="$scope"/>
        <xsl:with-param name="role" select="$role"/>
@@ -466,7 +466,7 @@
     </xsl:choose>
 
     <xsl:if test="$refs[not(d:tertiary)]/*[self::d:see]">
-      <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see', concat(&primary;, &sep;, &secondary;, &sep;, &sep;, d:see))[&scope;][1])]"
+      <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see', concat(&primary;, &sep;, &secondary;, &sep;, &sep;, d:see))[&scope;])]"
                            mode="index-see">
         <xsl:with-param name="scope" select="$scope"/>
         <xsl:with-param name="role" select="$role"/>
@@ -479,14 +479,14 @@
 
   <xsl:if test="$refs/d:tertiary or $refs[not(d:tertiary)]/*[self::d:seealso]">
     <fo:block start-indent="2pc">
-      <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see-also', concat(&primary;, &sep;, &secondary;, &sep;, &sep;, d:seealso))[&scope;][1])]"
+      <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see-also', concat(&primary;, &sep;, &secondary;, &sep;, &sep;, d:seealso))[&scope;])]"
                            mode="index-seealso">
           <xsl:with-param name="scope" select="$scope"/>
           <xsl:with-param name="role" select="$role"/>
           <xsl:with-param name="type" select="$type"/>
           <xsl:sort select="translate(d:seealso, &lowercase;, &uppercase;)"/>
       </xsl:apply-templates>
-      <xsl:apply-templates select="$refs[d:tertiary and count(.|key('tertiary', concat($key, &sep;, &tertiary;))[&scope;][1]) = 1]"
+      <xsl:apply-templates select="$refs[d:tertiary and generate-id() = generate-id(key('tertiary', concat($key, &sep;, &tertiary;))[&scope;])]"
                            mode="index-tertiary">
           <xsl:with-param name="scope" select="$scope"/>
           <xsl:with-param name="role" select="$role"/>
@@ -587,7 +587,7 @@
     </xsl:choose>
 
     <xsl:if test="$refs/d:see">
-      <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see', concat(&primary;, &sep;, &secondary;, &sep;, &tertiary;, &sep;, d:see))[&scope;][1])]"
+      <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see', concat(&primary;, &sep;, &secondary;, &sep;, &tertiary;, &sep;, d:see))[&scope;])]"
                            mode="index-see">
         <xsl:with-param name="scope" select="$scope"/>
         <xsl:with-param name="role" select="$role"/>
@@ -600,7 +600,7 @@
 
   <xsl:if test="$refs/d:seealso">
     <fo:block>
-      <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see-also', concat(&primary;, &sep;, &secondary;, &sep;, &tertiary;, &sep;, d:seealso))[&scope;][1])]"
+      <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see-also', concat(&primary;, &sep;, &secondary;, &sep;, &tertiary;, &sep;, d:seealso))[&scope;])]"
                            mode="index-seealso">
         <xsl:with-param name="scope" select="$scope"/>
         <xsl:with-param name="role" select="$role"/>
@@ -675,7 +675,7 @@
       </fo:basic-link>
 
       <xsl:if test="key('endofrange', $id)[&scope;]">
-        <xsl:apply-templates select="key('endofrange', $id)[&scope;][last()]"
+        <xsl:apply-templates select="(key('endofrange', $id)[&scope;])[last()]"
                              mode="reference">
           <xsl:with-param name="scope" select="$scope"/>
           <xsl:with-param name="role" select="$role"/>
@@ -898,8 +898,8 @@
   <xsl:param name="role" select="@role"/>
   <xsl:param name="type" select="@type"/>
 
-  <xsl:variable name="terms" select="$scope//d:indexterm[count(.|key('letter',
-                                     translate(substring(&primary;, 1, 1),&lowercase;,&uppercase;))[&scope;][1]) = 1]"/>
+  <xsl:variable name="terms" select="$scope//d:indexterm[generate-id() = generate-id(key('letter',
+                                     translate(substring(&primary;, 1, 1),&lowercase;,&uppercase;))[&scope;])]"/>
   <xsl:variable name="alphabetical"
                 select="$terms[contains(concat(&lowercase;, &uppercase;),
                                         substring(&primary;, 1, 1))]"/>
@@ -915,8 +915,8 @@
       <xsl:with-param name="key" select="'index symbols'"/>
     </xsl:call-template>
     <xsl:text>&lt;/title&gt;&#10;</xsl:text>
-    <xsl:apply-templates select="$others[count(.|key('primary',
-                                 &primary;)[&scope;][1]) = 1]"
+    <xsl:apply-templates select="$others[generate-id() = generate-id(key('primary',
+                                 &primary;)[&scope;])]"
                          mode="index-symbol-div-markup">
       <xsl:with-param name="scope" select="$scope"/>
       <xsl:with-param name="role" select="$role"/>
@@ -926,8 +926,8 @@
     <xsl:text>&lt;/indexdiv&gt;&#10;</xsl:text>
   </xsl:if>
 
-  <xsl:apply-templates select="$alphabetical[count(.|key('letter',
-                               translate(substring(&primary;, 1, 1),&lowercase;,&uppercase;))[&scope;][1]) = 1]"
+  <xsl:apply-templates select="$alphabetical[generate-id() = generate-id(key('letter',
+                               translate(substring(&primary;, 1, 1),&lowercase;,&uppercase;))[&scope;])]"
                        mode="index-div-markup">
       <xsl:with-param name="scope" select="$scope"/>
       <xsl:with-param name="role" select="$role"/>
@@ -962,7 +962,7 @@
   <xsl:value-of select="translate($key, &lowercase;, &uppercase;)"/>
   <xsl:text>&lt;/title&gt;&#10;</xsl:text>
 
-  <xsl:apply-templates select="key('letter', $key)[&scope;][count(.|key('primary', &primary;)[&scope;][1]) = 1]"
+  <xsl:apply-templates select="key('letter', $key)[&scope;][generate-id() = generate-id(key('primary', &primary;)[&scope;])]"
                        mode="index-primary-markup">
     <xsl:with-param name="scope" select="$scope"/>
     <xsl:with-param name="role" select="$role"/>
@@ -978,7 +978,7 @@
   <xsl:param name="type" select="''"/>
   <xsl:variable name="key" select="translate(substring(&primary;, 1, 1),&lowercase;,&uppercase;)"/>
 
-  <xsl:apply-templates select="key('letter', $key)[&scope;][count(.|key('primary', &primary;)[&scope;][1]) = 1]"
+  <xsl:apply-templates select="key('letter', $key)[&scope;][generate-id() = generate-id(key('primary', &primary;)[&scope;])]"
                        mode="index-primary-markup">
     <xsl:with-param name="scope" select="$scope"/>
     <xsl:with-param name="role" select="$role"/>
@@ -1016,7 +1016,7 @@
   <xsl:text>&lt;/primaryie&gt;&#10;</xsl:text>
 
   <xsl:if test="$refs/d:secondary or $refs[not(d:secondary)]/*[self::d:see or self::d:seealso]">
-    <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see', concat(&primary;, &sep;, &sep;, &sep;, d:see))[&scope;][1])]"
+    <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see', concat(&primary;, &sep;, &sep;, &sep;, d:see))[&scope;])]"
                          mode="index-see-markup">
       <xsl:with-param name="scope" select="$scope"/>
       <xsl:with-param name="role" select="$role"/>
@@ -1024,7 +1024,7 @@
       <xsl:sort select="translate(d:see, &lowercase;, &uppercase;)"/>
     </xsl:apply-templates>
 
-    <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see-also', concat(&primary;, &sep;, &sep;, &sep;, d:seealso))[&scope;][1])]"
+    <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see-also', concat(&primary;, &sep;, &sep;, &sep;, d:seealso))[&scope;])]"
                          mode="index-seealso-markup">
       <xsl:with-param name="scope" select="$scope"/>
       <xsl:with-param name="role" select="$role"/>
@@ -1032,7 +1032,7 @@
       <xsl:sort select="translate(d:seealso, &lowercase;, &uppercase;)"/>
     </xsl:apply-templates>
 
-    <xsl:apply-templates select="$refs[d:secondary and count(.|key('secondary', concat($key, &sep;, &secondary;))[&scope;][1]) = 1]"
+    <xsl:apply-templates select="$refs[d:secondary and generate-id() = generate-id(key('secondary', concat($key, &sep;, &secondary;))[&scope;])]"
                          mode="index-secondary-markup">
       <xsl:with-param name="scope" select="$scope"/>
       <xsl:with-param name="role" select="$role"/>
@@ -1071,21 +1071,21 @@
   <xsl:text>&lt;/secondaryie&gt;&#10;</xsl:text>
 
   <xsl:if test="$refs/d:tertiary or $refs[not(d:tertiary)]/*[self::d:see or self::d:seealso]">
-    <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see', concat(&primary;, &sep;, &secondary;, &sep;, &sep;, d:see))[&scope;][1])]"
+    <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see', concat(&primary;, &sep;, &secondary;, &sep;, &sep;, d:see))[&scope;])]"
                          mode="index-see-markup">
       <xsl:with-param name="scope" select="$scope"/>
       <xsl:with-param name="role" select="$role"/>
       <xsl:with-param name="type" select="$type"/>
       <xsl:sort select="translate(d:see, &lowercase;, &uppercase;)"/>
     </xsl:apply-templates>
-    <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see-also', concat(&primary;, &sep;, &secondary;, &sep;, &sep;, d:seealso))[&scope;][1])]"
+    <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see-also', concat(&primary;, &sep;, &secondary;, &sep;, &sep;, d:seealso))[&scope;])]"
                          mode="index-seealso-markup">
       <xsl:with-param name="scope" select="$scope"/>
       <xsl:with-param name="role" select="$role"/>
       <xsl:with-param name="type" select="$type"/>
       <xsl:sort select="translate(d:seealso, &lowercase;, &uppercase;)"/>
     </xsl:apply-templates>
-    <xsl:apply-templates select="$refs[d:tertiary and count(.|key('tertiary', concat($key, &sep;, &tertiary;))[&scope;][1]) = 1]"
+    <xsl:apply-templates select="$refs[d:tertiary and generate-id() = generate-id(key('tertiary', concat($key, &sep;, &tertiary;))[&scope;])]"
                          mode="index-tertiary-markup">
       <xsl:with-param name="scope" select="$scope"/>
       <xsl:with-param name="role" select="$role"/>
@@ -1124,14 +1124,14 @@
 
   <xsl:variable name="see" select="$refs/d:see | $refs/d:seealso"/>
   <xsl:if test="$see">
-    <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see', concat(&primary;, &sep;, &secondary;, &sep;, &tertiary;, &sep;, d:see))[&scope;][1])]"
+    <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see', concat(&primary;, &sep;, &secondary;, &sep;, &tertiary;, &sep;, d:see))[&scope;])]"
                          mode="index-see-markup">
       <xsl:with-param name="scope" select="$scope"/>
       <xsl:with-param name="role" select="$role"/>
       <xsl:with-param name="type" select="$type"/>
       <xsl:sort select="translate(d:see, &lowercase;, &uppercase;)"/>
     </xsl:apply-templates>
-    <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see-also', concat(&primary;, &sep;, &secondary;, &sep;, &tertiary;, &sep;, d:seealso))[&scope;][1])]"
+    <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see-also', concat(&primary;, &sep;, &secondary;, &sep;, &tertiary;, &sep;, d:seealso))[&scope;])]"
                          mode="index-seealso-markup">
       <xsl:with-param name="scope" select="$scope"/>
       <xsl:with-param name="role" select="$role"/>

--- a/xsl/html/autoidx.xsl
+++ b/xsl/html/autoidx.xsl
@@ -697,7 +697,7 @@
         <xsl:attribute name="href">
           <xsl:call-template name="href.target">
             <xsl:with-param name="object" select="$target[1]"/>
-            <xsl:with-param name="context" select="//d:index[&scope;][1]"/>
+            <xsl:with-param name="context" select="(//d:index[&scope;])[1]"/>
           </xsl:call-template>
         </xsl:attribute>
         <xsl:apply-templates select="$target[1]" mode="index-title-content"/>

--- a/xsl/html/autoidx.xsl
+++ b/xsl/html/autoidx.xsl
@@ -115,11 +115,11 @@
 
   <xsl:variable name="terms"
                 select="//d:indexterm
-                        [count(.|key('letter',
+                        [generate-id() = generate-id(key('letter',
                           translate(substring(&primary;, 1, 1),
                              &lowercase;,
                              &uppercase;))
-                          [&scope;][1]) = 1
+                          [&scope;])
                           and not(@class = 'endofrange')]"/>
 
   <xsl:variable name="alphabetical"
@@ -133,7 +133,7 @@
     <xsl:if test="$others">
       <xsl:choose>
         <xsl:when test="normalize-space($type) != '' and 
-                        $others[@type = $type][count(.|key('primary', &primary;)[&scope;][1]) = 1]">
+          $others[@type = $type][generate-id() = generate-id(key('primary', &primary;)[&scope;])]">
           <div class="indexdiv">
             <h3>
               <xsl:call-template name="gentext">
@@ -141,7 +141,7 @@
               </xsl:call-template>
             </h3>
             <dl>
-              <xsl:apply-templates select="$others[count(.|key('primary', &primary;)[&scope;][1]) = 1]"
+              <xsl:apply-templates select="$others[generate-id() = generate-id(key('primary', &primary;)[&scope;])]"
                                    mode="index-symbol-div">
                 <xsl:with-param name="position" select="position()"/>                                
                 <xsl:with-param name="scope" select="$scope"/>
@@ -163,8 +163,8 @@
               </xsl:call-template>
             </h3>
             <dl>
-              <xsl:apply-templates select="$others[count(.|key('primary',
-                                          &primary;)[&scope;][1]) = 1]"
+              <xsl:apply-templates select="$others[generate-id() = generate-id(key('primary',
+                                          &primary;)[&scope;])]"
                                   mode="index-symbol-div">
                 <xsl:with-param name="position" select="position()"/>                                
                 <xsl:with-param name="scope" select="$scope"/>
@@ -178,9 +178,9 @@
       </xsl:choose>
     </xsl:if>
 
-    <xsl:apply-templates select="$alphabetical[count(.|key('letter',
+    <xsl:apply-templates select="$alphabetical[generate-id() = generate-id(key('letter',
                                  translate(substring(&primary;, 1, 1),
-                                           &lowercase;,&uppercase;))[&scope;][1]) = 1]"
+                                           &lowercase;,&uppercase;))[&scope;])]"
                          mode="index-div-basic">
       <xsl:with-param name="position" select="position()"/>
       <xsl:with-param name="scope" select="$scope"/>
@@ -253,8 +253,8 @@
                 select="translate(substring(&primary;, 1, 1),
                          &lowercase;,&uppercase;)"/>
 
-  <xsl:if test="key('letter', $key)[&scope;]
-                [count(.|key('primary', &primary;)[&scope;][1]) = 1]">
+  <xsl:if test="key('letter', $key)
+                [generate-id() = generate-id(key('primary', &primary;)[&scope;])]">
     <div class="indexdiv">
       <xsl:if test="contains(concat(&lowercase;, &uppercase;), $key)">
         <h3>
@@ -262,9 +262,9 @@
         </h3>
       </xsl:if>
       <dl>
-        <xsl:apply-templates select="key('letter', $key)[&scope;]
-                                     [count(.|key('primary', &primary;)
-                                     [&scope;][1])=1]"
+        <xsl:apply-templates select="key('letter', $key)
+                                     [generate-id() = generate-id(key('primary', &primary;)
+                                     [&scope;])]"
                              mode="index-primary">
           <xsl:with-param name="position" select="position()"/>
           <xsl:with-param name="scope" select="$scope"/>
@@ -286,7 +286,7 @@
                                              &lowercase;,&uppercase;)"/>
 
   <xsl:apply-templates select="key('letter', $key)
-                               [&scope;][count(.|key('primary', &primary;)[1]) = 1]"
+                            [generate-id() = generate-id(key('primary', &primary;)[&scope;])]"
                        mode="index-primary">
     <xsl:with-param name="position" select="position()"/>
     <xsl:with-param name="scope" select="$scope"/>
@@ -327,7 +327,7 @@
     <xsl:value-of select="d:primary"/>
     <xsl:choose>
       <xsl:when test="$index.links.to.section = 1">
-        <xsl:for-each select="$refs[@zone != '' or generate-id() = generate-id(key('primary-section', concat($key, &sep;, &section.id;))[&scope;][1])]">
+        <xsl:for-each select="$refs[@zone != '' or generate-id() = generate-id(key('primary-section', concat($key, &sep;, &section.id;))[&scope;])]">
           <xsl:apply-templates select="." mode="reference">
             <xsl:with-param name="position" select="position()"/>
             <xsl:with-param name="scope" select="$scope"/>
@@ -350,7 +350,7 @@
     </xsl:choose>
 
     <xsl:if test="$refs[not(d:secondary)]/*[self::d:see]">
-      <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see', concat(&primary;, &sep;, &sep;, &sep;, d:see))[&scope;][1])]"
+      <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see', concat(&primary;, &sep;, &sep;, &sep;, d:see))[&scope;])]"
                            mode="index-see">
         <xsl:with-param name="position" select="position()"/>
         <xsl:with-param name="scope" select="$scope"/>
@@ -364,7 +364,7 @@
     <xsl:when test="$refs/d:secondary or $refs[not(d:secondary)]/*[self::d:seealso]">
       <dd>
         <dl>
-          <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see-also', concat(&primary;, &sep;, &sep;, &sep;, d:seealso))[&scope;][1])]"
+          <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see-also', concat(&primary;, &sep;, &sep;, &sep;, d:seealso))[&scope;])]"
                                mode="index-seealso">
             <xsl:with-param name="position" select="position()"/>
             <xsl:with-param name="scope" select="$scope"/>
@@ -372,7 +372,7 @@
             <xsl:with-param name="type" select="$type"/>
             <xsl:sort select="translate(d:seealso, &lowercase;, &uppercase;)"/>
           </xsl:apply-templates>
-          <xsl:apply-templates select="$refs[d:secondary and count(.|key('secondary', concat($key, &sep;, &secondary;))[&scope;][1]) = 1]"
+          <xsl:apply-templates select="$refs[d:secondary and generate-id() = generate-id(key('secondary', concat($key, &sep;, &secondary;))[&scope;])]"
                                mode="index-secondary">
             <xsl:with-param name="position" select="position()"/>
             <xsl:with-param name="scope" select="$scope"/>
@@ -415,7 +415,7 @@
     <xsl:value-of select="d:secondary"/>
     <xsl:choose>
       <xsl:when test="$index.links.to.section = 1">
-        <xsl:for-each select="$refs[@zone != '' or generate-id() = generate-id(key('secondary-section', concat($key, &sep;, &section.id;))[&scope;][1])]">
+        <xsl:for-each select="$refs[@zone != '' or generate-id() = generate-id(key('secondary-section', concat($key, &sep;, &section.id;))[&scope;])]">
           <xsl:apply-templates select="." mode="reference">
             <xsl:with-param name="position" select="position()"/>
             <xsl:with-param name="scope" select="$scope"/>
@@ -438,7 +438,7 @@
     </xsl:choose>
 
     <xsl:if test="$refs[not(d:tertiary)]/*[self::d:see]">
-      <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see', concat(&primary;, &sep;, &secondary;, &sep;, &sep;, d:see))[&scope;][1])]"
+      <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see', concat(&primary;, &sep;, &secondary;, &sep;, &sep;, d:see))[&scope;])]"
                            mode="index-see">
         <xsl:with-param name="position" select="position()"/>
         <xsl:with-param name="scope" select="$scope"/>
@@ -452,7 +452,7 @@
     <xsl:when test="$refs/d:tertiary or $refs[not(d:tertiary)]/*[self::d:seealso]">
       <dd>
         <dl>
-          <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see-also', concat(&primary;, &sep;, &secondary;, &sep;, &sep;, d:seealso))[&scope;][1])]"
+          <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see-also', concat(&primary;, &sep;, &secondary;, &sep;, &sep;, d:seealso))[&scope;])]"
                                mode="index-seealso">
             <xsl:with-param name="position" select="position()"/>
             <xsl:with-param name="scope" select="$scope"/>
@@ -460,7 +460,7 @@
             <xsl:with-param name="type" select="$type"/>
             <xsl:sort select="translate(d:seealso, &lowercase;, &uppercase;)"/>
           </xsl:apply-templates>
-          <xsl:apply-templates select="$refs[d:tertiary and count(.|key('tertiary', concat($key, &sep;, &tertiary;))[&scope;][1]) = 1]"
+          <xsl:apply-templates select="$refs[d:tertiary and generate-id() = generate-id(key('tertiary', concat($key, &sep;, &tertiary;))[&scope;])]"
                                mode="index-tertiary">
             <xsl:with-param name="position" select="position()"/>
             <xsl:with-param name="scope" select="$scope"/>
@@ -503,7 +503,7 @@
     <xsl:value-of select="d:tertiary"/>
     <xsl:choose>
       <xsl:when test="$index.links.to.section = 1">
-        <xsl:for-each select="$refs[@zone != '' or generate-id() = generate-id(key('tertiary-section', concat($key, &sep;, &section.id;))[&scope;][1])]">
+        <xsl:for-each select="$refs[@zone != '' or generate-id() = generate-id(key('tertiary-section', concat($key, &sep;, &section.id;))[&scope;])]">
           <xsl:apply-templates select="." mode="reference">
             <xsl:with-param name="position" select="position()"/>
             <xsl:with-param name="scope" select="$scope"/>
@@ -525,7 +525,7 @@
     </xsl:choose>
 
     <xsl:if test="$refs/d:see">
-      <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see', concat(&primary;, &sep;, &secondary;, &sep;, &tertiary;, &sep;, d:see))[&scope;][1])]"
+      <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see', concat(&primary;, &sep;, &secondary;, &sep;, &tertiary;, &sep;, d:see))[&scope;])]"
                            mode="index-see">
         <xsl:with-param name="position" select="position()"/>
         <xsl:with-param name="scope" select="$scope"/>
@@ -539,7 +539,7 @@
     <xsl:when test="$refs/d:seealso">
       <dd>
         <dl>
-          <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see-also', concat(&primary;, &sep;, &secondary;, &sep;, &tertiary;, &sep;, d:seealso))[&scope;][1])]"
+          <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see-also', concat(&primary;, &sep;, &secondary;, &sep;, &tertiary;, &sep;, d:seealso))[&scope;])]"
                                mode="index-seealso">
             <xsl:with-param name="position" select="position()"/>
             <xsl:with-param name="scope" select="$scope"/>
@@ -643,7 +643,7 @@
 
       <xsl:variable name="id" select="(@id|@xml:id)[1]"/>
       <xsl:if test="key('endofrange', $id)[&scope;]">
-        <xsl:apply-templates select="key('endofrange', $id)[&scope;][last()]"
+        <xsl:apply-templates select="(key('endofrange', $id)[&scope;])[last()]"
                              mode="reference">
           <xsl:with-param name="position" select="position()"/>
           <xsl:with-param name="scope" select="$scope"/>
@@ -673,7 +673,7 @@
         <xsl:attribute name="href">
           <xsl:call-template name="href.target">
             <xsl:with-param name="object" select="$target[1]"/>
-            <xsl:with-param name="context" select="//d:index[&scope;][1]"/>
+            <xsl:with-param name="context" select="(//d:index[&scope;])[1]"/>
           </xsl:call-template>
         </xsl:attribute>
         <xsl:apply-templates select="$target[1]" mode="index-title-content"/>


### PR DESCRIPTION
This PR fixes, in templates from autoidx.xsl, many failed applications of the '[&scope;]' predicate--which include each instance of deploying "Muenchian grouping". The fixes included here are from only the to-FO and to-HTML versions of autoidx.xsl (--as I prefer to wait, to see how well this PR is received, before expending energy on the others ;).

Explanation:

Although grouping was not implemented, as such, in XSLT before v. 2.0, there were ways to get the effect in 1.0. Grouping is the operation DocBook XSL uses in generating indexes (see autoidx.xsl) to gather in one place all the indexterms that are of the current index's @type, and whose primary value begins with this particular indexterm's primary's first letter[, and which have this indexterm's primary value[, and which have X characteristic[, and Y characteristic[, and ... etc. etc.]]]].

The way it's done in pre-2.0 XSLT is to catalog the actual groups in the data, by checking through, say, the indexterms (maybe using an <xsl:key>) and checking whether the current indexterm is the FIRST of all those (in the current index's "scope") that are of the current index's particular @type (if any) and which have this indexterm's particular primary value (and, if any, its particular "seealso" value; as well as perhaps its secondary value, etc., etc.). All grouping like this, that involves more than one "group characteristic", is COMPOSITE-KEY grouping (which we're familiar with from so many SQL Select statements).

An efficient way to do the grouping in pre-2.0 XSLT is what some call "Muenchian grouping" (which Michael Kay discusses in his book XSLT, 2d ed., pp. 625-27). That is what the authors of autoidx.xsl chose to use--as Jirka Kosec mentioned in his helpful paper on "Using XSLT for getting back-of-the-book indexes".

However, to do COMPOSITE-KEY grouping with this technique, is not as easy as falling out of bed; one must think through how one intends to accomplish it. (The 2d edition of Dr. Kay's wonderful book foregoes examples for such grouping--more's the pity.)

A simple way to accomplish such grouping, at least in certain scenarios, is to concatenate the strings together that constitute the composite key's values. The Muenchian grouping in autoidx.xsl uses quite a few <xsl:key>s constructed with such concatenation, e.g. this one concatenating some indexterms' &primary; values (including any 'seealso' value) and section-IDs:

    <xsl:key name="primary-section"
         match="d:indexterm[not(d:secondary) and not(d:see)]"
         use="concat(&primary;, &sep;, &section.id;)"/>

The contributors to autoidx.xsl have (for whatever reasons) not opted to incorporate @role and (post-DocBook-4.2) @type into the composite grouping-key in that way. Rather, they bundled certain tests, such as "$type = @type", into the '&scope;' entity. This entity they then applied as a predicate in all the XPaths that seek to carry out the Muenchian grouping. But, unfortunately, the WAY (or rather, WAYS) that they apply this predicate breaks the XPaths.

"Oh? How does it break them?" One must answer that question individually for each of the two forms of XPath they used (both of which forms, Dr. Kay's book illustrates). First, let's consider the following form (ignoring the particular &lt;xsl:key&gt; this example uses, which is not pertinent):

    //d:indexterm[generate-id(.) = generate-id(key('primary', &primary;)[&scope;][1])]

Again, this is for finding the indexterms that are the first with their particular constellation of (whichever are the relevant) characteristics. Dr. Kay points out that using the '[1]' predicate here is actually redundant: "generate-id()" considers only the first node, anyway, in the supplied node-set.

But notice the (relevant) difference in the example Dr. Kay gave for that form:

    /cities/city[generate-id(.) = generate-id(key('country-key', @country)[1])]

In addition to the parts in Dr. Kay's example, the autoidx.xsl code inserts into the XPath, without further ado, '[&scope;]'. The problem here is that predicates in the same XPath step, just strung together "without further ado", are connected together only by the "AND" logical operator: that is, each predicate is applied separately and individually--NOT to any predicates they follow immediately, but just to the step itself to which the predicates pertain. 

Thus, the meaning of the above filtering of //d:indexterm is NOT (what it SHOULD mean):

    "Give us each indexterm that is THE FIRST, within the current index's scope, that 1) has the indexterm's particular primary-value AND 2) has (if any) its particular @type (or @role)."

Rather, it means:

    "Give us each indexterm that is in the current index's scope, and is of its particular @type (or @role), if any, AND ALSO (by the way) is THE FIRST (of any, in any scope and of any @type) that has the indexterm's particular primary-value."

If the former meaning is the one we want--and indeed it is--then we can get it either by adding a pair of brackets to the above, with the closing one just before the '[1]' (which, following hard on the '[&scope;]' predicate, was no longer redundant, but detrimental), to get:

    //d:indexterm[generate-id(.) = generate-id((key('primary', &primary;)[&scope;])[1])]

else we can get it by simply omitting the '[1]':

    //d:indexterm[generate-id(.) = generate-id(key('primary', &primary;)[&scope;])]

However, in the other XPath form for Muenchian grouping, the '[1]' is not redundant at all. But, having the '[&scope;]' predicate preceding it is destructive of the code's functionality:

    //d:indexterm[count(.|key('primary', &primary;)[&scope;][1]) = 1]

One must remember, whenever using this 'count()' technique for such a filter, that it makes TWO crucial assumptions:

        -- the node-set which the '[1]' helps qualify--which in this case is that returned by "key('primary', &primary;)[&scope;][1]"--will NEVER be the empty set
        
        -- that node-set will ALWAYS include (at the very least) the context node (.)

To see what's wrong with our predicate, here again it's helpful to see what it has different (relevantly) from Dr. Kay's example:

    /cities/city[count(.|key('country-key', @country)[1]) = 1]

And as before, the relevant difference is the insertion of '[&scope;]' into autoidx.xsl's XPath pattern. What that insertion does, here, is to explode BOTH of the two crucial assumptions the 'count(.|key(...)[1]=1)' form makes.

The solution for this predicate-form is simply to replace it, with the other, "generate-id" form--as we've now corrected it:

    //d:indexterm[generate-id(.) = generate-id(key('primary', &primary;)[&scope;])]

In addition to the applications of Muenchian grouping, three other deployments of '[&scope]' this PR has fixed include one place in both the FO and HTML versions of <xsl:template match="d:indexterm" mode="reference">:

    <xsl:apply-templates select="key('endofrange', $id)[&scope;][last()]" mode="reference">

has been emended by adding a bracket-pair in the XPath:

    <xsl:apply-templates select="(key('endofrange', $id)[&scope;])[last()]" mode="reference">

Similarly, in the HTML version of <xsl:template name="reference">:

    <xsl:with-param name="context" select="//d:index[&scope;][1]"/>

has been emended by adding a bracket-pair in the XPath:

    <xsl:with-param name="context" select="(//d:index[&scope;])[1]"/>

