### PR TITLE
move the @classpath-separator attribute to config element where saxon…

### DIFF
--- a/.travis/xmlc
+++ b/.travis/xmlc
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?> <!-- -*- nxml -*- -->
-<config>
-  <java classpath-separator=":" xml:id="java">
+<config classpath-separator=":">
+  <java xml:id="java">
     <system-property name="javax.xml.parsers.DocumentBuilderFactory"
 		     value="org.apache.xerces.jaxp.DocumentBuilderFactoryImpl"/>
     <system-property name="javax.xml.parsers.SAXParserFactory"


### PR DESCRIPTION
… perl script expects it.  The perl script uses this code:
$cpseparator = $doc->getAttribute('classpath-separator')
but the $doc node is <config>, not <java>, so it was never finding the attribute.