### PR TITLE
fix issue #46 inconsistent element selection for bookmarks

### DIFF
--- a/xsl/fo/docbook.xsl
+++ b/xsl/fo/docbook.xsl
@@ -358,11 +358,33 @@
   <xsl:apply-templates select="*" mode="bookmark"/>
 </xsl:template>
 
-<xsl:template match="d:set|d:book|d:part|d:reference|
-                     d:preface|d:chapter|d:appendix|d:article|d:topic
-                     |d:glossary|d:bibliography|d:index|d:setindex
-                     |d:refentry
-                     |d:sect1|d:sect2|d:sect3|d:sect4|d:sect5|d:section"
+<!-- to turn off any of these, add to your customization layer
+     an empty template matching on that element and in this mode -->
+<xsl:template match="d:appendix |
+                     d:article |
+                     d:bibliography |
+                     d:book |
+                     d:chapter |
+                     d:glossary |
+                     d:index |
+                     d:part |
+                     d:preface |
+                     d:refentry |
+                     d:reference |
+                     d:refsect1 |
+                     d:refsect2 |
+                     d:refsect3 |
+                     d:refsection |
+                     d:refsynopsisdiv |
+                     d:sect1 |
+                     d:sect2 |
+                     d:sect3 |
+                     d:sect4 |
+                     d:sect5 |
+                     d:section |
+                     d:set |
+                     d:setindex |
+                     d:topic"
               mode="bookmark">
 
   <xsl:variable name="id">

--- a/xsl/fo/fop.xsl
+++ b/xsl/fo/fop.xsl
@@ -32,10 +32,33 @@ translates characters with code>255 back to ASCII.
   <xsl:apply-templates select="*" mode="fop.outline"/>
 </xsl:template>
 
-<xsl:template match="d:set|d:book|d:part|d:reference|d:preface|d:chapter|d:appendix|d:article
-                     |d:glossary|d:bibliography|d:index|d:setindex
-                     |d:refentry
-                     |d:sect1|d:sect2|d:sect3|d:sect4|d:sect5|d:section"
+<!-- to turn off any of these, add to your customization layer
+     an empty template matching on that element and in this mode -->
+<xsl:template match="d:appendix |
+                     d:article |
+                     d:bibliography |
+                     d:book |
+                     d:chapter |
+                     d:glossary |
+                     d:index |
+                     d:part |
+                     d:preface |
+                     d:refentry |
+                     d:reference |
+                     d:refsect1 |
+                     d:refsect2 |
+                     d:refsect3 |
+                     d:refsection |
+                     d:refsynopsisdiv |
+                     d:sect1 |
+                     d:sect2 |
+                     d:sect3 |
+                     d:sect4 |
+                     d:sect5 |
+                     d:section |
+                     d:set |
+                     d:setindex |
+                     d:topic"
               mode="fop.outline">
   <xsl:variable name="id">
     <xsl:call-template name="object.id"/>

--- a/xsl/fo/fop1.xsl
+++ b/xsl/fo/fop1.xsl
@@ -21,12 +21,33 @@
   <xsl:apply-templates select="*" mode="fop1.outline"/>
 </xsl:template>
 
-<xsl:template match="d:set|d:book|d:part|d:reference|
-                     d:preface|d:chapter|d:appendix|d:article|d:topic
-                     |d:glossary|d:bibliography|d:index|d:setindex
-                     |d:refentry|d:refsynopsisdiv
-                     |d:refsect1|d:refsect2|d:refsect3|d:refsection
-                     |d:sect1|d:sect2|d:sect3|d:sect4|d:sect5|d:section"
+<!-- to turn off any of these, add to your customization layer
+     an empty template matching on that element and in this mode -->
+<xsl:template match="d:appendix |
+                     d:article |
+                     d:bibliography |
+                     d:book |
+                     d:chapter |
+                     d:glossary |
+                     d:index |
+                     d:part |
+                     d:preface |
+                     d:refentry |
+                     d:reference |
+                     d:refsect1 |
+                     d:refsect2 |
+                     d:refsect3 |
+                     d:refsection |
+                     d:refsynopsisdiv |
+                     d:sect1 |
+                     d:sect2 |
+                     d:sect3 |
+                     d:sect4 |
+                     d:sect5 |
+                     d:section |
+                     d:set |
+                     d:setindex |
+                     d:topic"
               mode="fop1.outline">
 
   <xsl:variable name="id">

--- a/xsl/fo/xep.xsl
+++ b/xsl/fo/xep.xsl
@@ -111,11 +111,33 @@
   <xsl:apply-templates select="*" mode="xep.outline"/>
 </xsl:template>
 
-<xsl:template match="d:set|d:book|d:part|d:reference|d:preface|d:chapter|d:appendix|d:article
-                     |d:glossary|d:bibliography|d:index|d:setindex|d:topic
-                     |d:refentry|d:refsynopsisdiv
-                     |d:refsect1|d:refsect2|d:refsect3|d:refsection
-                     |d:sect1|d:sect2|d:sect3|d:sect4|d:sect5|d:section"
+<!-- to turn off any of these, add to your customization layer
+     an empty template matching on that element and in this mode -->
+<xsl:template match="d:appendix |
+                     d:article |
+                     d:bibliography |
+                     d:book |
+                     d:chapter |
+                     d:glossary |
+                     d:index |
+                     d:part |
+                     d:preface |
+                     d:refentry |
+                     d:reference |
+                     d:refsect1 |
+                     d:refsect2 |
+                     d:refsect3 |
+                     d:refsection |
+                     d:refsynopsisdiv |
+                     d:sect1 |
+                     d:sect2 |
+                     d:sect3 |
+                     d:sect4 |
+                     d:sect5 |
+                     d:section |
+                     d:set |
+                     d:setindex |
+                     d:topic"
               mode="xep.outline">
   <xsl:variable name="id">
     <xsl:call-template name="object.id"/>


### PR DESCRIPTION
fix issue #46 inconsistent element selection for bookmarks.
I made the match attributes for modes bookmark, fop.outline, fop1.outline, and xep.outline the same so they will select the same elements across processors.