### PR TITLE
fix issue #34 Duplicate IDs output for HTML model tables

### DIFF
--- a/xsl/html/htmltbl.xsl
+++ b/xsl/html/htmltbl.xsl
@@ -72,7 +72,6 @@
                    | @frame
                    | @headers
                    | @height
-                   | @id
                    | @lang
                    | @nowrap
                    | @onclick


### PR DESCRIPTION
fix issue #34 Duplicate IDs output for HTML model tables.  Normally the id is placed on the div container if the param $generate.id.attributes=1, or an anchor is generated with the id if $generate.id.attributes=0. So the htmlTableAtts mode does not need to copy the id attribute from the source into the output table.