### PR TITLE
fix issue #28 assemble.xsl: imagedata filerefs in assembled output do…

### DIFF
--- a/xsl/assembly/assemble.xsl
+++ b/xsl/assembly/assemble.xsl
@@ -445,6 +445,9 @@
           <!-- must use for-each to set context node for xsl:copy -->
           <xsl:for-each select="$ref.content">
             <xsl:copy>
+              <xsl:attribute name="xml:base">
+                <xsl:value-of select="$fileref"/>
+              </xsl:attribute>
               <xsl:copy-of select="@*[not(name() = 'xml:id')]"/>
               <xsl:choose>
                 <!-- Use the module's xml:id if it has one -->
@@ -482,6 +485,9 @@
         <xsl:otherwise>
           <!-- create the element instead of copying it -->
           <xsl:element name="{$element.name}" namespace="http://docbook.org/ns/docbook">
+            <xsl:attribute name="xml:base">
+              <xsl:value-of select="$fileref"/>
+            </xsl:attribute>
             <xsl:copy-of select="$ref.content/@*[not(name() = 'xml:id')]"/>
             <xsl:choose>
               <!-- Use the module's xml:id if it has one -->


### PR DESCRIPTION
fix issue #28 assemble.xsl: imagedata filerefs in assembled output document may be incorrect.
Now an output element generated from a resourceref has an xml:base attribute added to it reflecting the location of the resource. That allows the existing processing of images to find paths relative to the resource.