### PR TITLE
fix issue #33 Timestamps in manpages considered bugs

### DIFF
--- a/xsl/manpages/other.xsl
+++ b/xsl/manpages/other.xsl
@@ -254,11 +254,15 @@
     </xsl:call-template>
     <xsl:text> &lt;http://docbook.sf.net/></xsl:text>
     <xsl:text>&#10;</xsl:text>
-    <xsl:text>.\"      Date: </xsl:text>
-    <xsl:call-template name="replace.dots.and.dashes">
-      <xsl:with-param name="content" select="$date"/>
-    </xsl:call-template>
-    <xsl:text>&#10;</xsl:text>
+    <!-- option to turn off date to avoid triggering version in
+         archive systems -->
+    <xsl:if test="$man.show.top.comment.date != 0">
+      <xsl:text>.\"      Date: </xsl:text>
+      <xsl:call-template name="replace.dots.and.dashes">
+        <xsl:with-param name="content" select="$date"/>
+      </xsl:call-template>
+      <xsl:text>&#10;</xsl:text>
+    </xsl:if>
     <xsl:text>.\"    Manual: </xsl:text>
     <xsl:call-template name="replace.dots.and.dashes">
       <xsl:with-param name="content" select="$manual"/>

--- a/xsl/manpages/param.ent
+++ b/xsl/manpages/param.ent
@@ -41,6 +41,7 @@
 <!ENTITY man.string.subst.map SYSTEM "../params/man.string.subst.map.xml">
 <!ENTITY man.subheading.divider.enabled SYSTEM "../params/man.subheading.divider.enabled.xml">
 <!ENTITY man.subheading.divider SYSTEM "../params/man.subheading.divider.xml">
+<!ENTITY man.show.top.comment.date SYSTEM "../params/man.show.top.comment.date.xml">
 <!ENTITY man.table.footnotes.divider SYSTEM "../params/man.table.footnotes.divider.xml">
 <!ENTITY man.th.extra1.suppress SYSTEM "../params/man.th.extra1.suppress.xml">
 <!ENTITY man.th.extra2.max.length SYSTEM "../params/man.th.extra2.max.length.xml">

--- a/xsl/manpages/param.xweb
+++ b/xsl/manpages/param.xweb
@@ -127,6 +127,7 @@
 &man.table.footnotes.divider;
 &man.subheading.divider.enabled;
 &man.subheading.divider;
+&man.show.top.comment.date;
   </reference>
   <appendix xml:id="stylesheet">
     <title>The Stylesheet</title>
@@ -192,6 +193,7 @@
 <src:fragref linkend="man.string.subst.map.local.pre.frag"/>
 <src:fragref linkend="man.subheading.divider.enabled.frag"/>
 <src:fragref linkend="man.subheading.divider.frag"/>
+<src:fragref linkend="man.show.top.comment.date.frag"/>
 <src:fragref linkend="man.table.footnotes.divider.frag"/>
 <src:fragref linkend="man.th.extra1.suppress.frag"/>
 <src:fragref linkend="man.th.extra2.max.length.frag"/>

--- a/xsl/params/man.show.top.comment.date.xml
+++ b/xsl/params/man.show.top.comment.date.xml
@@ -1,0 +1,36 @@
+<refentry xmlns="http://docbook.org/ns/docbook"
+          xmlns:xlink="http://www.w3.org/1999/xlink"
+          xmlns:xi="http://www.w3.org/2001/XInclude"
+          xmlns:src="http://nwalsh.com/xmlns/litprog/fragment"
+          xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+          version="5.0" xml:id="man.show.top.comment.date">
+<refmeta>
+<refentrytitle>man.show.top.comment.date</refentrytitle>
+<refmiscinfo class="other" otherclass="datatype">boolean</refmiscinfo>
+</refmeta>
+<refnamediv>
+<refname>man.show.top.comment.date</refname>
+<refpurpose>Include metadata date in top comment section</refpurpose>
+</refnamediv>
+
+<refsynopsisdiv>
+<src:fragment xml:id="man.show.top.comment.date.frag">
+<xsl:param name="man.show.top.comment.date">1</xsl:param></src:fragment>
+</refsynopsisdiv>
+
+<refsection><info><title>Description</title></info>
+
+<para>If non-zero, the metadata date is included in the group of metadata
+comments at the top of the generated man page file.  That group includes
+Title, Author, etc.  If the value is zero, then that date comment
+is omitted.  The default value is 1.</para>
+
+<para>If the refentry page info does not include a date element,
+then the current date is used, that is, the date the man page was generated from 
+the refentry. In archiving systems, this can trigger a change of version that
+is not desired when no changes were actually made.  This parameter allows you to
+omit the top comment date in the generated man page.
+</para>
+
+</refsection>
+</refentry>


### PR DESCRIPTION
fix issue #33 Timestamps in manpages considered bugs.
I only added one param to turn off the top comment date because that was the specific request.  If other comments need to be turned off, the customizer could customize the top.comment templates.