### PR TITLE
fix issue #63 XHTML generate.toc no suppress part toc title

### DIFF
--- a/xsl/html/division.xsl
+++ b/xsl/html/division.xsl
@@ -118,18 +118,26 @@
       </xsl:call-template>
     </xsl:variable>
     <xsl:if test="not(d:partintro) and contains($toc.params, 'toc')">
-      <xsl:call-template name="division.toc"/>
+      <xsl:call-template name="division.toc">
+        <xsl:with-param name="toc.title.p" select="contains($toc.params, 'title')"/>
+      </xsl:call-template>
     </xsl:if>
     <xsl:apply-templates/>
   </div>
 </xsl:template>
 
 <xsl:template match="d:part" mode="make.part.toc">
-  <xsl:call-template name="division.toc"/>
+  <xsl:param name="toc.title.p" select="true()"/>
+  <xsl:call-template name="division.toc">
+    <xsl:with-param name="toc.title.p" select="$toc.title.p"/>
+  </xsl:call-template>
 </xsl:template>
 
 <xsl:template match="d:reference" mode="make.part.toc">
-  <xsl:call-template name="division.toc"/>
+  <xsl:param name="toc.title.p" select="true()"/>
+  <xsl:call-template name="division.toc">
+    <xsl:with-param name="toc.title.p" select="$toc.title.p"/>
+  </xsl:call-template>
 </xsl:template>
 
 <xsl:template match="d:part/d:docinfo"></xsl:template>
@@ -159,7 +167,9 @@
     </xsl:variable>
     <xsl:if test="contains($toc.params, 'toc')">
       <!-- not ancestor::part because partintro appears in reference -->
-      <xsl:apply-templates select="parent::*" mode="make.part.toc"/>
+      <xsl:apply-templates select="parent::*" mode="make.part.toc">
+        <xsl:with-param name="toc.title.p" select="contains($toc.params, 'title')"/>
+      </xsl:apply-templates>
     </xsl:if>
     <xsl:call-template name="process.footnotes"/>
   </div>

--- a/xsl/html/refentry.xsl
+++ b/xsl/html/refentry.xsl
@@ -34,7 +34,9 @@
     </xsl:variable>
 
     <xsl:if test="not(d:partintro) and contains($toc.params, 'toc')">
-      <xsl:call-template name="division.toc"/>
+      <xsl:call-template name="division.toc">
+        <xsl:with-param name="toc.title.p" select="contains($toc.params, 'title')"/>
+      </xsl:call-template>
     </xsl:if>
     <xsl:apply-templates/>
   </div>


### PR DESCRIPTION
fix issue #63 XHTML generate.toc no suppress part toc title.
The toc.title.p param was not being passed to division.toc.
Also needed to change make.part.toc which is used when a partintro is used in either part or reference elements.