### PR TITLE
fix issue #52 add support for xrefs to inlines

### DIFF
--- a/xsl/common/entities.ent
+++ b/xsl/common/entities.ent
@@ -63,3 +63,17 @@
                                 parent::d:sect5|parent::d:section|parent::d:setindex|parent::d:sidebar|
                                 parent::d:simplesect|parent::d:taskprerequisites|parent::d:taskrelated|
                                 parent::d:tasksummary|parent::d:warning|parent::d:topic">
+
+<!-- Entity used in xref-to for inline elements -->
+<!ENTITY inline.elements "d:abbrev | d:accel | d:acronym | d:application | d:author | d:citation | d:citebiblioid
+                | d:citetitle | d:classname | d:code | d:command | d:computeroutput | d:constant | d:database
+                | d:date | d:editor | d:email | d:emphasis | d:envar | d:errorcode | d:errorname | d:errortext
+                | d:errortype | d:exceptionname | d:filename | d:firstterm | d:foreignphrase | d:function
+                | d:glossterm | d:guibutton | d:guiicon | d:guilabel | d:guimenu | d:guimenuitem | d:guisubmenu
+                | d:hardware | d:initializer | d:inlineequation | d:inlinemediaobject | d:interfacename | d:jobtitle
+                | d:keycap | d:keycode | d:keycombo | d:keysym | d:literal | d:markup | d:menuchoice | d:methodname
+                | d:modifier | d:mousebutton | d:nonterminal | d:ooclass | d:ooexception | d:oointerface
+                | d:option | d:optional | d:org | d:orgname | d:package | d:parameter | d:person | d:personname
+                | d:phrase | d:productname | d:productnumber | d:prompt | d:property | d:quote | d:replaceable
+                | d:returnvalue | d:shortcut | d:symbol | d:systemitem | d:tag | d:termdef | d:token | d:trademark
+                | d:type | d:uri | d:userinput | d:varname | d:wordasword">

--- a/xsl/fo/ebnf.xsl
+++ b/xsl/fo/ebnf.xsl
@@ -228,6 +228,7 @@ to be incomplete. Don't forget to read the source, too :-)</para>
 
   <fo:basic-link internal-destination="{$href}"
                  xsl:use-attribute-sets="xref.properties">
+    <xsl:call-template name="anchor"/>
     <xsl:choose>
       <xsl:when test="*|text()">
         <xsl:apply-templates/>

--- a/xsl/fo/graphics.xsl
+++ b/xsl/fo/graphics.xsl
@@ -571,7 +571,10 @@
 </xsl:template>
 
 <xsl:template match="d:inlinemediaobject">
-  <xsl:call-template name="select.mediaobject"/>
+  <fo:inline>
+    <xsl:call-template name="anchor"/>
+    <xsl:call-template name="select.mediaobject"/>
+  </fo:inline>
 </xsl:template>
 
 <!-- ==================================================================== -->

--- a/xsl/fo/inline.xsl
+++ b/xsl/fo/inline.xsl
@@ -182,6 +182,7 @@
   </xsl:param>
 
   <fo:inline font-family="{$sans.font.family}">
+    <xsl:call-template name="anchor"/>
     <xsl:choose>
       <xsl:when test="@dir">
         <fo:inline>
@@ -212,22 +213,25 @@
     </xsl:call-template>
   </xsl:param>
 
-  <xsl:choose>
-    <xsl:when test="@dir">
-      <fo:inline>
-        <xsl:attribute name="direction">
-          <xsl:choose>
-            <xsl:when test="@dir = 'ltr' or @dir = 'lro'">ltr</xsl:when>
-            <xsl:otherwise>rtl</xsl:otherwise>
-          </xsl:choose>
-        </xsl:attribute>
+  <fo:inline>
+    <xsl:call-template name="anchor"/>
+    <xsl:choose>
+      <xsl:when test="@dir">
+        <fo:inline>
+          <xsl:attribute name="direction">
+            <xsl:choose>
+              <xsl:when test="@dir = 'ltr' or @dir = 'lro'">ltr</xsl:when>
+              <xsl:otherwise>rtl</xsl:otherwise>
+            </xsl:choose>
+          </xsl:attribute>
+          <xsl:copy-of select="$contentwithlink"/>
+        </fo:inline>
+      </xsl:when>
+      <xsl:otherwise>
         <xsl:copy-of select="$contentwithlink"/>
-      </fo:inline>
-    </xsl:when>
-    <xsl:otherwise>
-      <xsl:copy-of select="$contentwithlink"/>
-    </xsl:otherwise>
-  </xsl:choose>
+      </xsl:otherwise>
+    </xsl:choose>
+  </fo:inline>
 </xsl:template>
 
 <xsl:template name="inline.monoseq">
@@ -268,6 +272,7 @@
   </xsl:param>
 
   <fo:inline font-weight="bold">
+    <xsl:call-template name="anchor"/>
     <xsl:if test="@dir">
       <xsl:attribute name="direction">
         <xsl:choose>
@@ -427,7 +432,10 @@
 <xsl:template match="d:author">
   <xsl:call-template name="simple.xlink">
     <xsl:with-param name="content">
-      <xsl:call-template name="person.name"/>
+      <fo:inline>
+        <xsl:call-template name="anchor"/>
+        <xsl:call-template name="person.name"/>
+      </fo:inline>
     </xsl:with-param>
   </xsl:call-template>
 </xsl:template>
@@ -435,7 +443,10 @@
 <xsl:template match="d:editor">
   <xsl:call-template name="simple.xlink">
     <xsl:with-param name="content">
-      <xsl:call-template name="person.name"/>
+      <fo:inline>
+        <xsl:call-template name="anchor"/>
+        <xsl:call-template name="person.name"/>
+      </fo:inline>
     </xsl:with-param>
   </xsl:call-template>
 </xsl:template>
@@ -443,7 +454,10 @@
 <xsl:template match="d:othercredit">
   <xsl:call-template name="simple.xlink">
     <xsl:with-param name="content">
-      <xsl:call-template name="person.name"/>
+      <fo:inline>
+        <xsl:call-template name="anchor"/>
+        <xsl:call-template name="person.name"/>
+      </fo:inline>
     </xsl:with-param>
   </xsl:call-template>
 </xsl:template>
@@ -773,7 +787,6 @@
 
 <xsl:template match="d:phrase">
   <fo:inline>
-    <xsl:call-template name="anchor"/>
     <xsl:call-template name="inline.charseq"/>
   </fo:inline>
 </xsl:template>
@@ -800,7 +813,6 @@
   </xsl:variable>
 
   <fo:inline>
-    <xsl:call-template name="anchor"/>
     <xsl:copy-of select="$content"/>
   </fo:inline>
 
@@ -967,6 +979,7 @@
 
 <xsl:template match="d:termdef">
   <fo:inline>
+    <xsl:call-template name="anchor"/>
     <xsl:call-template name="gentext.template">
       <xsl:with-param name="context" select="'termdef'"/>
       <xsl:with-param name="name" select="'prefix'"/>
@@ -1128,10 +1141,13 @@
       <xsl:otherwise>+</xsl:otherwise>
     </xsl:choose>
   </xsl:variable>
-  <xsl:for-each select="*">
-    <xsl:if test="position()>1"><xsl:value-of select="$joinchar"/></xsl:if>
-    <xsl:apply-templates select="."/>
-  </xsl:for-each>
+  <fo:inline>
+    <xsl:call-template name="anchor"/>
+    <xsl:for-each select="*">
+      <xsl:if test="position()>1"><xsl:value-of select="$joinchar"/></xsl:if>
+      <xsl:apply-templates select="."/>
+    </xsl:for-each>
+  </fo:inline>
 </xsl:template>
 
 <xsl:template match="d:uri">
@@ -1142,7 +1158,10 @@
 
 <xsl:template match="d:menuchoice">
   <xsl:variable name="shortcut" select="./d:shortcut"/>
-  <xsl:call-template name="process.menuchoice"/>
+  <fo:inline>
+    <xsl:call-template name="anchor"/>
+    <xsl:call-template name="process.menuchoice"/>
+  </fo:inline>
   <xsl:if test="$shortcut">
     <xsl:text> (</xsl:text>
     <xsl:apply-templates select="$shortcut"/>
@@ -1330,13 +1349,19 @@
 <!-- ==================================================================== -->
 
 <xsl:template match="d:person">
-  <xsl:apply-templates select="d:personname"/>
+  <fo:inline>
+    <xsl:call-template name="anchor"/>
+    <xsl:apply-templates select="d:personname"/>
+  </fo:inline>
 </xsl:template>
 
 <xsl:template match="d:personname">
   <xsl:call-template name="simple.xlink">
     <xsl:with-param name="content">
-      <xsl:call-template name="person.name"/>
+      <fo:inline>
+        <xsl:call-template name="anchor"/>
+        <xsl:call-template name="person.name"/>
+      </fo:inline>
     </xsl:with-param>
   </xsl:call-template>
 </xsl:template>
@@ -1344,7 +1369,10 @@
 <xsl:template match="d:jobtitle">
   <xsl:call-template name="simple.xlink">
     <xsl:with-param name="content">
-      <xsl:apply-templates/>
+      <fo:inline>
+        <xsl:call-template name="anchor"/>
+        <xsl:apply-templates/>
+      </fo:inline>
     </xsl:with-param>
   </xsl:call-template>
 </xsl:template>
@@ -1384,6 +1412,12 @@
   -->
   <!-- Since this is a mode, you can create different
        templates with different properties for different linking elements -->
+</xsl:template>
+
+<!-- ==================================================================== -->
+<!-- generate text for xrefs to inline elements -->
+<xsl:template match="&inline.elements;" mode="xref-to">
+  <xsl:apply-templates mode="no.anchor.mode"/>
 </xsl:template>
 
 </xsl:stylesheet>

--- a/xsl/fo/math.xsl
+++ b/xsl/fo/math.xsl
@@ -15,7 +15,10 @@
      ******************************************************************** -->
 
 <xsl:template match="d:inlineequation">
-  <xsl:apply-templates/>
+  <fo:inline>
+    <xsl:call-template name="anchor"/>
+    <xsl:apply-templates/>
+  </fo:inline>
 </xsl:template>
 
 <xsl:template match="d:alt">
@@ -23,6 +26,7 @@
 
 <xsl:template match="d:mathphrase">
   <fo:inline>
+    <xsl:call-template name="anchor"/>
     <xsl:apply-templates/>
   </fo:inline>
 </xsl:template>

--- a/xsl/fo/synop.xsl
+++ b/xsl/fo/synop.xsl
@@ -975,8 +975,11 @@
 </xsl:template>
 
 <!-- Used when not occurring as a child of classsynopsis -->
-<xsl:template match="d:ooclass|d:oointerface|d:ooexception">
-  <xsl:apply-templates/>
+<xsl:template match="d:ooclass|d:oointerface|d:ooexception|d:modifier|d:initializer">
+  <fo:inline>
+    <xsl:call-template name="anchor"/>
+    <xsl:apply-templates/>
+  </fo:inline>
 </xsl:template>
 
 <!-- ==================================================================== -->

--- a/xsl/html/inline.xsl
+++ b/xsl/html/inline.xsl
@@ -1589,4 +1589,10 @@
   <!-- does nothing; this *is not* markup to force a page break. -->
 </xsl:template>
 
+<!-- ==================================================================== -->
+<!-- generate text for xrefs to inline elements -->
+<xsl:template match="&inline.elements;" mode="xref-to">
+  <xsl:apply-templates mode="no.anchor.mode"/>
+</xsl:template>
+
 </xsl:stylesheet>


### PR DESCRIPTION
fix issue #52 add support for xrefs to inlines. This started with an issue of an xref to a property element not working, but I realized that xrefs to any inline did not work.  Although some inlines can contain other inline elements, I don't see any problem copying the content of an inline for an xref, as long as no.anchor.mode is used to strip out any links so there are no nested links.  This pull request adds support for xref to over 80 inline elements.