### PR TITLE
fix issue #49 xref to title in info resolves incorrectly

### DIFF
--- a/xsl/fo/xref.xsl
+++ b/xsl/fo/xref.xsl
@@ -314,7 +314,7 @@
   <xsl:choose>
     <!-- FIXME: how reliable is this? -->
     <xsl:when test="contains(local-name(parent::*), 'info')">
-      <xsl:apply-templates select="parent::*[2]" mode="xref-to">
+      <xsl:apply-templates select="ancestor::*[2]" mode="xref-to">
         <xsl:with-param name="referrer" select="$referrer"/>
         <xsl:with-param name="xrefstyle" select="$xrefstyle"/>
         <xsl:with-param name="verbose" select="$verbose"/>

--- a/xsl/html/xref.xsl
+++ b/xsl/html/xref.xsl
@@ -363,7 +363,7 @@
   <xsl:choose>
     <!-- FIXME: how reliable is this? -->
     <xsl:when test="contains(local-name(parent::*), 'info')">
-      <xsl:apply-templates select="parent::*[2]" mode="xref-to">
+      <xsl:apply-templates select="ancestor::*[2]" mode="xref-to">
         <xsl:with-param name="referrer" select="$referrer"/>
         <xsl:with-param name="xrefstyle" select="$xrefstyle"/>
         <xsl:with-param name="verbose" select="$verbose"/>


### PR DESCRIPTION
fix issue #49 xref to title in info resolves incorrectly.
If the title was inside an info element it was trying to find the container of the title using parent::*[2], which never works because an element has only one parent.  It should be ancestor::*[2].