### PR TITLE
fix issue #35 nested sets not showing in chunked next and prev

### DIFF
--- a/xsl/html/chunk-common.xsl
+++ b/xsl/html/chunk-common.xsl
@@ -241,6 +241,7 @@
 
   <xsl:variable name="prev"
     select="(preceding::d:book[1]
+             |preceding::d:set[1]
              |preceding::d:preface[1]
              |preceding::d:chapter[1]
              |preceding::d:appendix[1]
@@ -341,6 +342,7 @@
 
   <xsl:variable name="next"
     select="(following::d:book[1]
+             |following::d:set[1]
              |following::d:preface[1]
              |following::d:chapter[1]
              |following::d:appendix[1]
@@ -403,6 +405,7 @@
 
   <xsl:variable name="prev"
     select="(preceding::d:book[1]
+             |preceding::d:set[1]
              |preceding::d:preface[1]
              |preceding::d:chapter[1]
              |preceding::d:appendix[1]
@@ -448,6 +451,7 @@
 
   <xsl:variable name="next"
     select="(following::d:book[1]
+             |following::d:set[1]
              |following::d:preface[1]
              |following::d:chapter[1]
              |following::d:appendix[1]


### PR DESCRIPTION
fix issue #35 nested sets not showing in chunked next and prev.
Just needed to add d:set to the next and prev variables. They were not there before because set was always the outer document. With DocBook 5.1, sets and be nested and sequenced, so they need to be included in next and prev.