### PR TITLE
fix issue #54 autoidx does not respect generate.consistent.ids

### DIFF
--- a/xsl/fo/autoidx.xsl
+++ b/xsl/fo/autoidx.xsl
@@ -296,7 +296,8 @@
   <fo:block>
     <xsl:if test="$autolink.index.see != 0">
       <xsl:attribute name="id">
-        <xsl:value-of select="concat('ientry-', generate-id())"/>
+        <xsl:text>ientry-</xsl:text>
+        <xsl:call-template name="object.id"/>
       </xsl:attribute>
     </xsl:if>
     <xsl:if test="$axf.extensions != 0">
@@ -791,7 +792,10 @@
 
   <xsl:variable name="linkend">
     <xsl:if test="$seetarget">
-      <xsl:value-of select="concat('ientry-', generate-id($seetarget))"/>
+      <xsl:text>ientry-</xsl:text>
+      <xsl:call-template name="object.id">
+        <xsl:with-param name="object" select="$seetarget"/>
+      </xsl:call-template>
     </xsl:if>
   </xsl:variable>
   
@@ -853,7 +857,10 @@
 
     <xsl:variable name="linkend">
       <xsl:if test="$seealsotarget">
-        <xsl:value-of select="concat('ientry-', generate-id($seealsotarget))"/>
+        <xsl:text>ientry-</xsl:text>
+        <xsl:call-template name="object.id">
+          <xsl:with-param name="object" select="$seealsotarget"/>
+        </xsl:call-template>
       </xsl:if>
     </xsl:variable>
 

--- a/xsl/html/autoidx.xsl
+++ b/xsl/html/autoidx.xsl
@@ -307,7 +307,8 @@
     <xsl:if test="$autolink.index.see != 0">
       <!-- add internal id attribute to form see and seealso links -->
       <xsl:attribute name="id">
-        <xsl:value-of select="concat('ientry-', generate-id())"/>
+        <xsl:text>ientry-</xsl:text>
+        <xsl:call-template name="object.id"/>
       </xsl:attribute>
     </xsl:if>
     <xsl:for-each select="$refs/d:primary">
@@ -730,7 +731,10 @@
 
   <xsl:variable name="linkend">
     <xsl:if test="$seetarget">
-      <xsl:value-of select="concat('#ientry-', generate-id($seetarget))"/>
+      <xsl:text>#ientry-</xsl:text>
+      <xsl:call-template name="object.id">
+        <xsl:with-param name="object" select="$seetarget"/>
+      </xsl:call-template>
     </xsl:if>
   </xsl:variable>
 
@@ -789,7 +793,10 @@
 
     <xsl:variable name="linkend">
       <xsl:if test="$seealsotarget">
-        <xsl:value-of select="concat('#ientry-', generate-id($seealsotarget))"/>
+        <xsl:text>#ientry-</xsl:text>
+        <xsl:call-template name="object.id">
+          <xsl:with-param name="object" select="$seealsotarget"/>
+        </xsl:call-template>
       </xsl:if>
     </xsl:variable>
 


### PR DESCRIPTION
fix issue #54 autoidx does not respect generate.consistent.ids
Now it uses a call to the template named "object.id" instead of generate-id() function. The object.id template handles real id attributes, generate.consistent.ids, and falls back to generate-id() if necessary.