### PR TITLE
fix issue #41 Indexes in articles in a set collect index entries from…

### DIFF
--- a/xsl/html/autoidx.xsl
+++ b/xsl/html/autoidx.xsl
@@ -76,7 +76,22 @@
 
 
 <xsl:template name="generate-index">
-  <xsl:param name="scope" select="(ancestor::d:book|/)[last()]"/>
+  <!-- these are all the elements that can contain an index element -->
+  <xsl:param name="scope" select="(ancestor::d:book 
+                                 | ancestor::d:appendix 
+                                 | ancestor::d:article 
+                                 | ancestor::d:chapter 
+                                 | ancestor::d:part 
+                                 | ancestor::d:preface 
+                                 | ancestor::d:sect1 
+                                 | ancestor::d:sect2 
+                                 | ancestor::d:sect3 
+                                 | ancestor::d:sect4 
+                                 | ancestor::d:sect5 
+                                 | ancestor::d:section 
+                                 | ancestor::d:set
+                                 | ancestor::d:topic 
+                                 |/)[last()]"/>
 
   <xsl:choose>
     <xsl:when test="$index.method = 'kosek'">

--- a/xsl/html/index.xsl
+++ b/xsl/html/index.xsl
@@ -56,7 +56,6 @@
 
       <xsl:if test="count(d:indexentry) = 0 and count(d:indexdiv) = 0">
         <xsl:call-template name="generate-index">
-          <xsl:with-param name="scope" select="(ancestor::d:book|/)[last()]"/>
         </xsl:call-template>
       </xsl:if>
 
@@ -88,7 +87,6 @@
 
       <xsl:if test="count(d:indexentry) = 0 and count(d:indexdiv) = 0">
         <xsl:call-template name="generate-index">
-          <xsl:with-param name="scope" select="/"/>
         </xsl:call-template>
       </xsl:if>
 


### PR DESCRIPTION
fix issue #41 Indexes in articles in a set collect index entries from other articles in the set (HTML). The problem was that the scope parameter was not being properly set when generate-index template was called. Now it takes into account all the elements that can contain an index.