### PR TITLE
fix HTML indexes for scope conformance and type attribute selection

### DIFF
--- a/xsl/html/autoidx.xsl
+++ b/xsl/html/autoidx.xsl
@@ -128,74 +128,57 @@
     </xsl:if>
   </xsl:variable>
 
+  <!-- set of indexterms within scope, one for each unique primary first character -->
+  <!-- The scope takes into account the context of the index
+       element, and @type or @role -->
   <xsl:variable name="terms"
                 select="//d:indexterm
-                        [count(.|key('letter',
+                        [generate-id(.) = generate-id(key('letter',
                           translate(substring(&primary;, 1, 1),
                              &lowercase;,
                              &uppercase;))
-                          [&scope;][1]) = 1
+                          [&scope;])
                           and not(@class = 'endofrange')]"/>
 
+  <!-- subset of $terms that start with letters of the current alphabet -->
   <xsl:variable name="alphabetical"
                 select="$terms[contains(concat(&lowercase;, &uppercase;),
                                         substring(&primary;, 1, 1))]"/>
 
+  <!-- subset of $terms that start with other than letters of the current alphabet -->
   <xsl:variable name="others" select="$terms[not(contains(concat(&lowercase;,
                                                  &uppercase;),
                                              substring(&primary;, 1, 1)))]"/>
   <div class="index">
     <xsl:if test="$others">
-      <xsl:choose>
-        <xsl:when test="normalize-space($type) != '' and 
-                        $others[@type = $type][count(.|key('primary', &primary;)[&scope;][1]) = 1]">
-          <div class="indexdiv">
-            <h3>
-              <xsl:call-template name="gentext">
-                <xsl:with-param name="key" select="'index symbols'"/>
-              </xsl:call-template>
-            </h3>
-            <dl>
-              <xsl:apply-templates select="$others[count(.|key('primary', &primary;)[&scope;][1]) = 1]"
-                                   mode="index-symbol-div">
-                <xsl:with-param name="position" select="position()"/>                                
-                <xsl:with-param name="scope" select="$scope"/>
-                <xsl:with-param name="role" select="$role"/>
-                <xsl:with-param name="type" select="$type"/>
-                <xsl:sort select="translate(&primary;, &lowercase;, &uppercase;)"/>
-              </xsl:apply-templates>
-            </dl>
-          </div>
-        </xsl:when>
-        <xsl:when test="normalize-space($type) != ''"> 
-          <!-- Output nothing, as there isn't a match for $other using this $type -->
-        </xsl:when>  
-        <xsl:otherwise>
-          <div class="indexdiv">
-            <h3>
-              <xsl:call-template name="gentext">
-                <xsl:with-param name="key" select="'index symbols'"/>
-              </xsl:call-template>
-            </h3>
-            <dl>
-              <xsl:apply-templates select="$others[count(.|key('primary',
-                                          &primary;)[&scope;][1]) = 1]"
-                                  mode="index-symbol-div">
-                <xsl:with-param name="position" select="position()"/>                                
-                <xsl:with-param name="scope" select="$scope"/>
-                <xsl:with-param name="role" select="$role"/>
-                <xsl:with-param name="type" select="$type"/>
-                <xsl:sort select="translate(&primary;, &lowercase;, &uppercase;)"/>
-              </xsl:apply-templates>
-            </dl>
-          </div>
-        </xsl:otherwise>
-      </xsl:choose>
+      <!-- full set of non-letter indexterms in scope whose first character match any of $others -->
+      <xsl:variable name="others.in.index" 
+                    select="$others[generate-id(.) = generate-id(key('primary', &primary;)[&scope;])]"/>
+      <div class="indexdiv">
+        <h3>
+          <xsl:call-template name="gentext">
+            <xsl:with-param name="key" select="'index symbols'"/>
+          </xsl:call-template>
+        </h3>
+        <dl>
+          <xsl:apply-templates select="$others.in.index"
+                               mode="index-symbol-div">
+            <xsl:with-param name="position" select="position()"/>                                
+            <xsl:with-param name="scope" select="$scope"/>
+            <xsl:with-param name="role" select="$role"/>
+            <xsl:with-param name="type" select="$type"/>
+            <xsl:sort select="translate(&primary;, &lowercase;, &uppercase;)"/>
+          </xsl:apply-templates>
+        </dl>
+      </div>
     </xsl:if>
 
-    <xsl:apply-templates select="$alphabetical[count(.|key('letter',
+    <xsl:variable name="alphabetical.in.index"
+                  select="$alphabetical[generate-id(.) = generate-id(key('letter',
                                  translate(substring(&primary;, 1, 1),
-                                           &lowercase;,&uppercase;))[&scope;][1]) = 1]"
+                                           &lowercase;,&uppercase;))[&scope;])]"/>
+
+    <xsl:apply-templates select="$alphabetical.in.index"
                          mode="index-div-basic">
       <xsl:with-param name="position" select="position()"/>
       <xsl:with-param name="scope" select="$scope"/>
@@ -268,8 +251,8 @@
                 select="translate(substring(&primary;, 1, 1),
                          &lowercase;,&uppercase;)"/>
 
-  <xsl:if test="key('letter', $key)[&scope;]
-                [count(.|key('primary', &primary;)[&scope;][1]) = 1]">
+  <xsl:if test="key('letter', $key)
+                [generate-id(.) = generate-id(key('primary', &primary;)[&scope;])]">
     <div class="indexdiv">
       <xsl:if test="contains(concat(&lowercase;, &uppercase;), $key)">
         <h3>
@@ -277,9 +260,12 @@
         </h3>
       </xsl:if>
       <dl>
-        <xsl:apply-templates select="key('letter', $key)[&scope;]
-                                     [count(.|key('primary', &primary;)
-                                     [&scope;][1])=1]"
+        <xsl:variable name="these.terms" 
+                      select="key('letter', $key)
+                              [generate-id(.) = generate-id(key('primary', &primary;)
+                              [&scope;])]"/>
+        
+        <xsl:apply-templates select="$these.terms"
                              mode="index-primary">
           <xsl:with-param name="position" select="position()"/>
           <xsl:with-param name="scope" select="$scope"/>
@@ -301,7 +287,7 @@
                                              &lowercase;,&uppercase;)"/>
 
   <xsl:apply-templates select="key('letter', $key)
-                               [&scope;][count(.|key('primary', &primary;)[1]) = 1]"
+                               [generate-id(.) = generate-id(key('primary', &primary;)[&scope;])]"
                        mode="index-primary">
     <xsl:with-param name="position" select="position()"/>
     <xsl:with-param name="scope" select="$scope"/>
@@ -388,7 +374,10 @@
             <xsl:with-param name="type" select="$type"/>
             <xsl:sort select="translate(d:seealso, &lowercase;, &uppercase;)"/>
           </xsl:apply-templates>
-          <xsl:apply-templates select="$refs[d:secondary and count(.|key('secondary', concat($key, &sep;, &secondary;))[&scope;][1]) = 1]"
+          <xsl:variable name="secondaries" 
+                        select="$refs[d:secondary and 
+                        generate-id() = generate-id(key('secondary', concat($key, &sep;, &secondary;))[&scope;])]"/>
+          <xsl:apply-templates select="$secondaries"
                                mode="index-secondary">
             <xsl:with-param name="position" select="position()"/>
             <xsl:with-param name="scope" select="$scope"/>
@@ -431,7 +420,7 @@
     <xsl:value-of select="d:secondary"/>
     <xsl:choose>
       <xsl:when test="$index.links.to.section = 1">
-        <xsl:for-each select="$refs[@zone != '' or generate-id() = generate-id(key('secondary-section', concat($key, &sep;, &section.id;))[&scope;][1])]">
+        <xsl:for-each select="$refs[@zone != '' or generate-id() = generate-id(key('secondary-section', concat($key, &sep;, &section.id;))[&scope;])]">
           <xsl:apply-templates select="." mode="reference">
             <xsl:with-param name="position" select="position()"/>
             <xsl:with-param name="scope" select="$scope"/>
@@ -454,7 +443,7 @@
     </xsl:choose>
 
     <xsl:if test="$refs[not(d:tertiary)]/*[self::d:see]">
-      <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see', concat(&primary;, &sep;, &secondary;, &sep;, &sep;, d:see))[&scope;][1])]"
+      <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see', concat(&primary;, &sep;, &secondary;, &sep;, &sep;, d:see))[&scope;])]"
                            mode="index-see">
         <xsl:with-param name="position" select="position()"/>
         <xsl:with-param name="scope" select="$scope"/>
@@ -468,7 +457,7 @@
     <xsl:when test="$refs/d:tertiary or $refs[not(d:tertiary)]/*[self::d:seealso]">
       <dd>
         <dl>
-          <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see-also', concat(&primary;, &sep;, &secondary;, &sep;, &sep;, d:seealso))[&scope;][1])]"
+          <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see-also', concat(&primary;, &sep;, &secondary;, &sep;, &sep;, d:seealso))[&scope;])]"
                                mode="index-seealso">
             <xsl:with-param name="position" select="position()"/>
             <xsl:with-param name="scope" select="$scope"/>
@@ -476,7 +465,12 @@
             <xsl:with-param name="type" select="$type"/>
             <xsl:sort select="translate(d:seealso, &lowercase;, &uppercase;)"/>
           </xsl:apply-templates>
-          <xsl:apply-templates select="$refs[d:tertiary and count(.|key('tertiary', concat($key, &sep;, &tertiary;))[&scope;][1]) = 1]"
+
+          <xsl:variable name="tertiaries"
+                        select="$refs[d:tertiary and 
+                        generate-id(.) = generate-id(key('tertiary', concat($key, &sep;, &tertiary;))[&scope;])]"/>
+
+          <xsl:apply-templates select="$tertiaries"
                                mode="index-tertiary">
             <xsl:with-param name="position" select="position()"/>
             <xsl:with-param name="scope" select="$scope"/>
@@ -519,7 +513,7 @@
     <xsl:value-of select="d:tertiary"/>
     <xsl:choose>
       <xsl:when test="$index.links.to.section = 1">
-        <xsl:for-each select="$refs[@zone != '' or generate-id() = generate-id(key('tertiary-section', concat($key, &sep;, &section.id;))[&scope;][1])]">
+        <xsl:for-each select="$refs[@zone != '' or generate-id() = generate-id(key('tertiary-section', concat($key, &sep;, &section.id;))[&scope;])]">
           <xsl:apply-templates select="." mode="reference">
             <xsl:with-param name="position" select="position()"/>
             <xsl:with-param name="scope" select="$scope"/>
@@ -541,7 +535,7 @@
     </xsl:choose>
 
     <xsl:if test="$refs/d:see">
-      <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see', concat(&primary;, &sep;, &secondary;, &sep;, &tertiary;, &sep;, d:see))[&scope;][1])]"
+      <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see', concat(&primary;, &sep;, &secondary;, &sep;, &tertiary;, &sep;, d:see))[&scope;])]"
                            mode="index-see">
         <xsl:with-param name="position" select="position()"/>
         <xsl:with-param name="scope" select="$scope"/>
@@ -555,7 +549,7 @@
     <xsl:when test="$refs/d:seealso">
       <dd>
         <dl>
-          <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see-also', concat(&primary;, &sep;, &secondary;, &sep;, &tertiary;, &sep;, d:seealso))[&scope;][1])]"
+          <xsl:apply-templates select="$refs[generate-id() = generate-id(key('see-also', concat(&primary;, &sep;, &secondary;, &sep;, &tertiary;, &sep;, d:seealso))[&scope;])]"
                                mode="index-seealso">
             <xsl:with-param name="position" select="position()"/>
             <xsl:with-param name="scope" select="$scope"/>

--- a/xsl/html/index.xsl
+++ b/xsl/html/index.xsl
@@ -102,6 +102,11 @@
 <xsl:template match="d:index/d:title"></xsl:template>
 <xsl:template match="d:index/d:subtitle"></xsl:template>
 <xsl:template match="d:index/d:titleabbrev"></xsl:template>
+<xsl:template match="d:setindex/d:indexinfo"></xsl:template>
+<xsl:template match="d:setindex/d:info"></xsl:template>
+<xsl:template match="d:setindex/d:title"></xsl:template>
+<xsl:template match="d:setindex/d:subtitle"></xsl:template>
+<xsl:template match="d:setindex/d:titleabbrev"></xsl:template>
 
 <!-- ==================================================================== -->
 


### PR DESCRIPTION
This pull request incorporates changes submitted by Andrew Carver in pull request #67 in which he pointed out the the Muenchian grouping form using count() was not always correct, and proposed the alternate form using generate-id().  This pull request solves several outstanding indexing problems related to specialized indexes using @type attribute getting entries outside their scope, and the Symbols section being generated without any entries.