### PR TITLE
fix infinite recursion when inlinemediaobject in figure/title

### DIFF
--- a/xsl/html/graphics.xsl
+++ b/xsl/html/graphics.xsl
@@ -651,6 +651,8 @@ valign: <xsl:value-of select="@valign"/></xsl:message>
                 <xsl:when test="$alt != ''">
                   <xsl:copy-of select="$alt"/>
                 </xsl:when>
+                <xsl:when test="ancestor::d:inlinemediaobject">
+                </xsl:when>
                 <xsl:when test="ancestor::d:figure">
                   <xsl:variable name="fig.title">
                     <xsl:apply-templates select="ancestor::d:figure/d:title/node()"/>


### PR DESCRIPTION
fix infinite recursion when inlinemediaobject in figure/title. The problem was in the process.image.attribute template where it tried to add an alt attribute, but it used ancestor::d:figure to get the title, so when it tried to process that element again it hit the same call and ended in an infinite recursion. The solution was to test for ancestor::inlinemediaobject in the xsl:choose for alt and do nothing.