### PR TITLE
fix issue #62 Make use of alternate text set for mediaobject

### DIFF
--- a/xsl/fo/graphics.xsl
+++ b/xsl/fo/graphics.xsl
@@ -6,11 +6,13 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:d="http://docbook.org/ns/docbook"
 		xmlns:fo="http://www.w3.org/1999/XSL/Format"
+                xmlns:axf="http://www.antennahouse.com/names/XSL/Extensions"
+		xmlns:fox="http://xmlgraphics.apache.org/fop/extensions"
                 xmlns:xlink="http://www.w3.org/1999/xlink"
                 xmlns:stext="http://nwalsh.com/xslt/ext/com.nwalsh.saxon.TextFactory"
                 xmlns:xtext="com.nwalsh.xalan.Text"
                 xmlns:lxslt="http://xml.apache.org/xslt"
-                exclude-result-prefixes="xlink stext xtext lxslt d"
+                exclude-result-prefixes="axf fox xlink stext xtext lxslt d"
                 extension-element-prefixes="stext xtext"
                 version='1.0'>
 
@@ -373,6 +375,25 @@
     <xsl:call-template name="image.valign"/>
   </xsl:variable>
 
+  <xsl:variable name="phrases"
+                select="ancestor::d:mediaobject/d:textobject[d:phrase]
+                        |ancestor::d:inlinemediaobject/d:textobject[d:phrase]
+                        |ancestor::d:mediaobjectco/d:textobject[d:phrase]"/>
+
+  <xsl:variable name="alt">
+    <xsl:choose>
+      <xsl:when test="ancestor::d:mediaobject[1]/d:alt">
+        <xsl:apply-templates select="ancestor::d:mediaobject[1]/d:alt"/>
+      </xsl:when>
+      <xsl:when test="ancestor::d:inlinemediaobject[1]/d:alt">
+        <xsl:apply-templates select="ancestor::d:inlinemediaobject[1]/d:alt"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:apply-templates select="$phrases[not(@role) or @role!='tex'][1]"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:variable>
+
   <xsl:variable name="element.name">
     <xsl:choose>
       <xsl:when test="svg:*" xmlns:svg="http://www.w3.org/2000/svg">
@@ -393,6 +414,21 @@
       <xsl:attribute name="src">
         <xsl:value-of select="$src"/>
       </xsl:attribute>
+    </xsl:if>
+
+    <xsl:if test="$alt != ''">
+      <xsl:choose>
+        <xsl:when test="$fop1.extensions != 0">
+          <xsl:attribute name="fox:alt-text">
+            <xsl:value-of select="$alt"/>
+          </xsl:attribute>
+        </xsl:when>
+        <xsl:when test="$axf.extensions != 0">
+          <xsl:attribute name="axf:alttext">
+            <xsl:value-of select="$alt"/>
+          </xsl:attribute>
+        </xsl:when>
+      </xsl:choose>
     </xsl:if>
 
     <xsl:if test="$width != ''">
@@ -813,4 +849,11 @@
   </xsl:choose>
 </xsl:template>
 
+<xsl:template match="d:mediaobject/d:alt | d:inlinemediaobject/d:alt">
+  <xsl:variable name="content">
+    <xsl:apply-templates/>
+  </xsl:variable>
+  <!-- take the text only -->
+  <xsl:value-of select="$content"/>
+</xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
fix issue #62 Make use of alternate text set for mediaobject.
Implemented for fop1.extensions and axf.extensions per the issue text.