### PR TITLE
fix issue #59 man: mishandles footnotes in tables

### DIFF
--- a/xsl/manpages/table.xsl
+++ b/xsl/manpages/table.xsl
@@ -97,7 +97,17 @@
           <xsl:for-each select="descendant-or-self::d:table|descendant-or-self::d:informaltable">
             <xsl:element name="{local-name(..)}">
               <table>
-                <xsl:apply-templates mode="stripNS" select="*"/>
+                <!-- strip namespace from docbook HTML table markup if present -->
+                <xsl:apply-templates mode="strip.html.table.ns" select="*"/>
+                <xsl:if test=".//d:footnote|../d:title//d:footnote">
+                  <tbody class="footnotes">
+                    <tr>
+                      <td colspan="{@cols}">
+                        <xsl:apply-templates select=".//d:footnote|../d:title//d:footnote" mode="table.footnote.mode"/>
+                      </td>
+                    </tr>
+                  </tbody>
+                </xsl:if>
               </table>
             </xsl:element>
           </xsl:for-each>
@@ -122,5 +132,39 @@
       <xsl:with-param name="center" select="$center"/>
     </xsl:call-template>
   </xsl:template>
+
+<!-- strip namespace only from docbook html markup elements -->
+<xsl:template match="d:tbody
+                    |d:caption
+                    |d:col
+                    |d:colgroup
+                    |d:thead
+                    |d:tfoot
+                    |d:tr
+                    |d:th
+                    |d:td" mode="strip.html.table.ns">
+  <xsl:element name="{local-name(.)}">
+    <xsl:copy-of select="@*[not(name(.) = 'xml:id')
+                            and not(name(.) = 'version')]"/>
+    <xsl:if test="@xml:id">
+      <xsl:attribute name="id">
+        <xsl:value-of select="@xml:id"/>
+      </xsl:attribute>
+    </xsl:if>
+    <xsl:apply-templates mode="strip.html.table.ns"/>
+  </xsl:element>
+</xsl:template>
+
+<!-- do not strip namespace from cell contents -->
+<xsl:template match="*|text()|processing-instruction()|comment()" mode="strip.html.table.ns">
+  <!-- process in normal mode -->
+  <xsl:apply-templates select="."/>
+  <!--
+  <xsl:copy>
+    <xsl:copy-of select="@*"/>
+    <xsl:apply-templates mode="strip.html.table.ns"/>
+  </xsl:copy>
+  -->
+</xsl:template>
 
 </xsl:stylesheet>

--- a/xsl/manpages/tbl.xsl
+++ b/xsl/manpages/tbl.xsl
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsl:stylesheet 
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
+  xmlns:d="http://docbook.org/ns/docbook"
   xmlns:exsl="http://exslt.org/common"
   exclude-result-prefixes="exsl"
   version="1.0">
@@ -11,10 +12,14 @@ The HTML comes either from an HTML-markup table in the source,
 stripped of docbook namespace if necessary, or from applying
 the stock DocBook HTML templates to a CALS table. -->
 
+<!--
 <xsl:import href="../common/stripns.xsl"/>
+-->
 
 <xsl:template match="*" mode="fix.namespace">
+  <!--
   <xsl:apply-templates select="." mode="stripNS"/>
+  -->
 </xsl:template>
 
 
@@ -481,10 +486,10 @@ the stock DocBook HTML templates to a CALS table. -->
   <!-- * ============================================================== -->
   <!-- *    table footnotes                                      -->
   <!-- * ============================================================== -->
-  <xsl:template match="footnote" mode="table.footnote.mode">
-    <xsl:variable name="footnotes" select=".//footnote"/>
+  <xsl:template match="d:footnote" mode="table.footnote.mode">
+    <xsl:variable name="footnotes" select=".//d:footnote"/>
     <xsl:variable name="table.footnotes"
-                  select=".//tgroup//footnote"/>
+                  select=".//tgroup//d:footnote"/>
     <xsl:value-of select="$man.table.footnotes.divider"/>
     <xsl:text>&#10;</xsl:text>
     <xsl:text>.br&#10;</xsl:text>
@@ -495,21 +500,9 @@ the stock DocBook HTML templates to a CALS table. -->
   <!-- * The following template for footnote.body.number mode was just -->
   <!-- * lifted from the HTML stylesheets with some minor adjustments -->
   <xsl:template match="*"  mode="footnote.body.number">
-    <xsl:variable name="name">
-      <xsl:text>ftn.</xsl:text>
-      <xsl:call-template name="object.id">
-        <xsl:with-param name="object" select="ancestor::footnote"/>
-      </xsl:call-template>
-    </xsl:variable>
-    <xsl:variable name="href">
-      <xsl:text>#</xsl:text>
-      <xsl:call-template name="object.id">
-        <xsl:with-param name="object" select="ancestor::footnote"/>
-      </xsl:call-template>
-    </xsl:variable>
     <xsl:variable name="footnote.mark">
       <xsl:text>[</xsl:text>
-      <xsl:apply-templates select="ancestor::footnote"
+      <xsl:apply-templates select="ancestor::d:footnote"
                            mode="footnote.number"/>
       <xsl:text>]&#10;</xsl:text>
     </xsl:variable>
@@ -538,9 +531,9 @@ the stock DocBook HTML templates to a CALS table. -->
     </xsl:choose>
   </xsl:template>
 
-  <!-- * The HTML stylesheets output <sup><a>...</a></sup> around -->
+  <!-- * The HTML stylesheets output <a><sup>...</sup></a> around -->
   <!-- * footnote markers in tables -->
-  <xsl:template match="th/sup">
+  <xsl:template match="a/sup">
     <xsl:apply-templates/>
   </xsl:template>
   <xsl:template match="a">


### PR DESCRIPTION
fix issue #59 man: mishandles footnotes in tables.
This issue triggered a re-examination of how tables are handled in man pages, especially for the namespaced stylesheet version. The basic idea of tables is to first convert them to HTML tables in no namespace, then apply special templates in manpages/tbl.xsl to convert HTML elements to tbl markup. The original fix for the namespaced stylesheet was to strip the namespace of a DocBook HTML markup table in the DocBook 5 namespace, but this also stripped the namespace of other DocBook elements within the table such as para, footnote, emphasis, etc.  But then the manpage templates matching on the namespaced elements no longer matched.  This commit replaces the mode="stripNS" with a mode="strip.html.table.ns" new to manpages to only strip the namespace from the HTML table elements.  Then the HTML table processing had to add the templates to generate the footnote row for the generated internal HTML table. That fixed most of the problem, then some small adjustments to a few templates to get it all working. 