### PR TITLE
fix issue #45 Title not centering in namespaced fo stylesheets

### DIFF
--- a/xsl/params/component.title.properties.xml
+++ b/xsl/params/component.title.properties.xml
@@ -3,6 +3,7 @@
           xmlns:xi="http://www.w3.org/2001/XInclude"
           xmlns:src="http://nwalsh.com/xmlns/litprog/fragment"
           xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+          exclude-result-prefixes="xi src"
           version="5.0" xml:id="component.title.properties">
 <refmeta>
 <refentrytitle>component.title.properties</refentrytitle>
@@ -23,7 +24,7 @@
   <xsl:attribute name="hyphenate">false</xsl:attribute>
   <xsl:attribute name="text-align">
     <xsl:choose>
-      <xsl:when test="((parent::article | parent::articleinfo | parent::info/parent::article) and not(ancestor::book) and not(self::bibliography))         or (parent::slides | parent::slidesinfo)">center</xsl:when>
+      <xsl:when test="((parent::*[local-name() = 'article'] | parent::*[local-name() = 'articleinfo'] | parent::*[local-name() = 'info']/parent::*[local-name() = 'article']) and not(ancestor::*[local-name() = 'book']) and not(self::*[local-name() = 'bibliography'])) or (parent::*[local-name() = 'slides'] | parent::*[local-name() = 'slidesinfo'])">center</xsl:when>
       <xsl:otherwise>start</xsl:otherwise>
     </xsl:choose>
   </xsl:attribute>


### PR DESCRIPTION
fix issue #45 Title not centering in namespaced fo stylesheets. The only element names referenced in params appear in component.title.properties.xml. I altered the param to use test of local-name() so it will work in both namespaced and non-namespaced versions.