### PR TITLE
fix issue #39 change word from hardcoded to gentext

### DIFF
--- a/gentext/locale/en.xml
+++ b/gentext/locale/en.xml
@@ -150,6 +150,7 @@
 <gentext key="Editedby" text="Edited by"/>
 <gentext key="editedby" text="Edited by"/>
 <gentext key="in" text="in"/>
+<gentext key="In" text="In"/>
 <gentext key="lastlistcomma" text=","/>
 <gentext key="listcomma" text=","/>
 <gentext key="notes" text="Notes"/>

--- a/xsl/fo/biblio-iso690.xsl
+++ b/xsl/fo/biblio-iso690.xsl
@@ -169,7 +169,10 @@
 <!-- Contribution -->
   <xsl:apply-templates mode="iso690.paper.part" select="./d:biblioset[@relation='part']"/>
 <!-- In -->
-  <xsl:text>In </xsl:text>
+  <xsl:call-template name="gentext">
+    <xsl:with-param name="key">In</xsl:with-param>
+  </xsl:call-template>
+  <xsl:text> </xsl:text>
 <!-- Host -->
   <xsl:apply-templates mode="iso690.paper.book" select="./d:biblioset[@relation='book']"/>
 </xsl:template>

--- a/xsl/html/biblio-iso690.xsl
+++ b/xsl/html/biblio-iso690.xsl
@@ -169,7 +169,10 @@
 <!-- Contribution -->
   <xsl:apply-templates mode="iso690.paper.part" select="./d:biblioset[@relation='part']"/>
 <!-- In -->
-  <xsl:text>In </xsl:text>
+  <xsl:call-template name="gentext">
+    <xsl:with-param name="key">In</xsl:with-param>
+  </xsl:call-template>
+  <xsl:text> </xsl:text>
 <!-- Host -->
   <xsl:apply-templates mode="iso690.paper.book" select="./d:biblioset[@relation='book']"/>
 </xsl:template>


### PR DESCRIPTION
fix issue #39 change word from hardcoded to gentext.
The word "In" in biblio-iso690.xsl was hardcoded, and was converted to gentext with key "In" so it could be translated and customized.