### PR TITLE
fix issue #109 manpages extra white space namespace mismatch

### DIFF
--- a/xsl/common/common.xsl
+++ b/xsl/common/common.xsl
@@ -68,7 +68,6 @@ d:subjectset d:substeps d:synopfragment d:table d:tbody d:textobject d:tfoot d:t
 d:thead d:tip d:toc d:tocchap d:toclevel1 d:toclevel2 d:toclevel3 d:toclevel4
 d:toclevel5 d:tocpart d:topic d:varargs d:variablelist d:varlistentry d:videodata
 d:videoobject d:void d:warning d:subjectset
-
 d:classsynopsis
 d:constructorsynopsis
 d:destructorsynopsis
@@ -80,6 +79,45 @@ d:ooexception
 d:oointerface
 d:simplemsgentry
 d:manvolnum
+"/>
+<xsl:strip-space elements="
+abstract affiliation anchor answer appendix area areaset areaspec
+artheader article audiodata audioobject author authorblurb authorgroup
+beginpage bibliodiv biblioentry bibliography biblioset blockquote book
+bookinfo callout calloutlist caption caution chapter
+citerefentry cmdsynopsis co collab colophon colspec confgroup
+copyright dedication docinfo editor entrytbl epigraph equation
+example figure footnote footnoteref formalpara funcprototype
+funcsynopsis glossary glossdef glossdiv glossentry glosslist graphicco
+group highlights imagedata imageobject imageobjectco important index
+indexdiv indexentry indexterm info informalequation informalexample
+informalfigure informaltable inlineequation inlinemediaobject
+itemizedlist itermset keycombo keywordset legalnotice listitem lot
+mediaobject mediaobjectco menuchoice msg msgentry msgexplan msginfo
+msgmain msgrel msgset msgsub msgtext note objectinfo
+orderedlist othercredit part partintro preface printhistory procedure
+programlistingco publisher qandadiv qandaentry qandaset question
+refentry reference refmeta refnamediv refsection refsect1 refsect1info refsect2
+refsect2info refsect3 refsect3info refsynopsisdiv refsynopsisdivinfo
+revhistory revision row sbr screenco screenshot sect1 sect1info sect2
+sect2info sect3 sect3info sect4 sect4info sect5 sect5info section
+sectioninfo seglistitem segmentedlist seriesinfo set setindex setinfo
+shortcut sidebar simplelist simplesect spanspec step subject
+subjectset substeps synopfragment table tbody textobject tfoot tgroup
+thead tip toc tocchap toclevel1 toclevel2 toclevel3 toclevel4
+toclevel5 tocpart topic varargs variablelist varlistentry videodata
+videoobject void warning subjectset
+classsynopsis
+constructorsynopsis
+destructorsynopsis
+fieldsynopsis
+methodparam
+methodsynopsis
+ooclass
+ooexception
+oointerface
+simplemsgentry
+manvolnum
 "/>
 <!-- ====================================================================== -->
 


### PR DESCRIPTION
fix issue #109 manpages extra white space namespace mismatch.
The extra whitespace was coming from xsl:strip-space missing element names of the opposite namespace to the stylesheet being used.  The processing otherwise worked, but the strip-space mismatch meant it did not work, leaving whitespace in the output that messed up nroff processing. The solution was to add a second xsl:strip-space with no namespace prefixes, and then adjust the build of nons to not add the namespace prefix to those elements.