### PR TITLE
fix bug #108 indexterm before listitem triggers extra blank line

### DIFF
--- a/xsl/fo/admon.xsl
+++ b/xsl/fo/admon.xsl
@@ -80,6 +80,10 @@
                 </xsl:attribute>
               </fo:external-graphic>
             </fo:block>
+            <!-- include leading indexterms in this part to prevent
+                 extra spacing above first para from its space-before -->
+            <xsl:apply-templates mode="leading.indexterms" 
+                                 select="child::d:indexterm[not(preceding-sibling::*)]"/>
           </fo:list-item-label>
           <fo:list-item-body start-indent="body-start()">
             <xsl:if test="$admon.textlabel != 0 or d:title or d:info/d:title">
@@ -90,7 +94,7 @@
               </fo:block>
             </xsl:if>
             <fo:block xsl:use-attribute-sets="admonition.properties">
-              <xsl:apply-templates/>
+              <xsl:apply-templates select="*[not(self::d:indexterm[not(preceding-sibling::*)])]"/>
             </fo:block>
           </fo:list-item-body>
       </fo:list-item>

--- a/xsl/fo/glossary.xsl
+++ b/xsl/fo/glossary.xsl
@@ -777,6 +777,10 @@ GlossEntry ::=
         </xsl:choose>
         <xsl:apply-templates select="d:indexterm"/>
       </fo:block>
+      <!-- include leading indexterms in glossdef to prevent
+           extra spacing above first para from its space-before -->
+      <xsl:apply-templates mode="leading.indexterms" 
+                           select="d:glossdef/d:indexterm[not(preceding-sibling::*)]"/>
     </fo:list-item-label>
 
     <fo:list-item-body start-indent="body-start()">
@@ -858,7 +862,8 @@ GlossEntry ::=
 </xsl:template>
 
 <xsl:template match="d:glossentry/d:glossdef" mode="glossary.as.list">
-  <xsl:apply-templates select="*[local-name(.) != 'glossseealso']"/>
+  <xsl:apply-templates select="*[local-name(.) != 'glossseealso' and
+                                 not(self::d:indexterm[not(preceding-sibling::*)])]"/>
   <xsl:if test="d:glossseealso">
     <fo:block>
       <xsl:variable name="template">

--- a/xsl/fo/lists.xsl
+++ b/xsl/fo/lists.xsl
@@ -134,10 +134,14 @@
           </xsl:with-param>
         </xsl:call-template>
       </fo:block>
+      <!-- include leading indexterms in this part to prevent
+           extra spacing above first para from its space-before -->
+      <xsl:apply-templates mode="leading.indexterms" 
+                           select="child::d:indexterm[not(preceding-sibling::*)]"/>
     </fo:list-item-label>
     <fo:list-item-body start-indent="body-start()">
       <fo:block>
-        <xsl:apply-templates/>
+        <xsl:apply-templates select="*[not(self::d:indexterm[not(preceding-sibling::*)])]"/>
       </fo:block>
     </fo:list-item-body>
   </xsl:variable>
@@ -162,6 +166,13 @@
       </fo:list-item>
     </xsl:otherwise>
   </xsl:choose>
+</xsl:template>
+
+<!-- process any <indexterms> appearing before other elements in
+     listitem here to prevent empty block that triggers space-before
+     of the first para in the listitem -->
+<xsl:template match="d:indexterm" mode="leading.indexterms">
+  <xsl:apply-templates select="."/>
 </xsl:template>
 
 <xsl:template name="itemizedlist.label.markup">
@@ -278,10 +289,14 @@
       <fo:block>
         <xsl:apply-templates select="." mode="item-number"/>
       </fo:block>
+      <!-- include leading indexterms in this part to prevent
+           extra spacing above first para from its space-before -->
+      <xsl:apply-templates mode="leading.indexterms" 
+                           select="child::d:indexterm[not(preceding-sibling::*)]"/>
     </fo:list-item-label>
     <fo:list-item-body start-indent="body-start()">
       <fo:block>
-        <xsl:apply-templates/>
+        <xsl:apply-templates select="*[not(self::d:indexterm[not(preceding-sibling::*)])]"/>
       </fo:block>
     </fo:list-item-body>
   </xsl:variable>
@@ -503,10 +518,16 @@
       <fo:block xsl:use-attribute-sets="variablelist.term.properties">
         <xsl:apply-templates select="d:term"/>
       </fo:block>
+      <!-- include leading indexterms in this part to prevent
+           extra spacing above first para from its space-before -->
+      <xsl:apply-templates mode="leading.indexterms" 
+                           select="d:listitem/d:indexterm[not(preceding-sibling::*)]"/>
     </fo:list-item-label>
     <fo:list-item-body start-indent="body-start()">
       <fo:block>
-        <xsl:apply-templates select="d:listitem"/>
+        <xsl:apply-templates select="d:listitem">
+          <xsl:with-param name="vl.as.list" select="1"/>
+        </xsl:apply-templates>
       </fo:block>
     </fo:list-item-body>
   </xsl:variable>
@@ -616,7 +637,15 @@
 </xsl:template>
 
 <xsl:template match="d:varlistentry/d:listitem">
-  <xsl:apply-templates/>
+  <xsl:param name="vl.as.list" select="0"/>
+  <xsl:choose>
+    <xsl:when test="$vl.as.list != 0">
+      <xsl:apply-templates select="*[not(self::d:indexterm[not(preceding-sibling::*)])]"/>
+    </xsl:when>
+    <xsl:otherwise>
+      <xsl:apply-templates/>
+    </xsl:otherwise>
+  </xsl:choose>
 </xsl:template>
 
 <!-- ==================================================================== -->
@@ -658,7 +687,7 @@
     </xsl:choose>
   </xsl:variable>
 
-  <fo:table id="{$id}" xsl:use-attribute-sets="simplelist.vertical.properties">
+  <fo:table id="{$id}" xsl:use-attribute-sets="normal.para.spacing">
 
     <xsl:choose>
       <xsl:when test="$axf.extensions != 0 or $xep.extensions != 0">
@@ -1013,10 +1042,14 @@
           </xsl:otherwise>
         </xsl:choose>
       </fo:block>
+      <!-- include leading indexterms in this part to prevent
+           extra spacing above first para from its space-before -->
+      <xsl:apply-templates mode="leading.indexterms" 
+                           select="child::d:indexterm[not(preceding-sibling::*)]"/>
     </fo:list-item-label>
     <fo:list-item-body start-indent="body-start()">
       <fo:block>
-        <xsl:apply-templates/>
+        <xsl:apply-templates select="*[not(self::d:indexterm[not(preceding-sibling::*)])]"/>
       </fo:block>
     </fo:list-item-body>
   </fo:list-item>
@@ -1047,10 +1080,14 @@
       <fo:block id="{$id}">
         <xsl:text>&#x2022;</xsl:text>
       </fo:block>
+      <!-- include leading indexterms in this part to prevent
+           extra spacing above first para from its space-before -->
+      <xsl:apply-templates mode="leading.indexterms" 
+                           select="child::d:indexterm[not(preceding-sibling::*)]"/>
     </fo:list-item-label>
     <fo:list-item-body start-indent="body-start()">
       <fo:block>
-        <xsl:apply-templates/>
+        <xsl:apply-templates select="*[not(self::d:indexterm[not(preceding-sibling::*)])]"/>
       </fo:block>
     </fo:list-item-body>
   </fo:list-item>
@@ -1303,10 +1340,14 @@
           <xsl:with-param name="arearefs" select="@arearefs"/>
         </xsl:call-template>
       </fo:block>
+      <!-- include leading indexterms in this part to prevent
+           extra spacing above first para from its space-before -->
+      <xsl:apply-templates mode="leading.indexterms" 
+                           select="child::d:indexterm[not(preceding-sibling::*)]"/>
     </fo:list-item-label>
     <fo:list-item-body start-indent="body-start()">
       <fo:block>
-        <xsl:apply-templates/>
+        <xsl:apply-templates select="*[not(self::d:indexterm[not(preceding-sibling::*)])]"/>
       </fo:block>
     </fo:list-item-body>
   </fo:list-item>

--- a/xsl/fo/qandaset.xsl
+++ b/xsl/fo/qandaset.xsl
@@ -269,16 +269,22 @@
           <fo:block/>
         </xsl:otherwise>
       </xsl:choose>
+      <!-- include leading indexterms in this part to prevent
+           extra spacing above first para from its space-before -->
+      <xsl:apply-templates mode="leading.indexterms" 
+                           select="child::d:indexterm[not(preceding-sibling::*)]"/>
     </fo:list-item-label>
     <fo:list-item-body start-indent="body-start()">
       <xsl:choose>
         <xsl:when test="$deflabel = 'none' and not(d:label)">
           <fo:block font-weight="bold">
-            <xsl:apply-templates select="*[local-name(.)!='label']"/>
+            <xsl:apply-templates select="*[local-name(.)!='label' and
+                                           not(self::d:indexterm[not(preceding-sibling::*)])]"/>
           </fo:block>
         </xsl:when>
         <xsl:otherwise>
-          <xsl:apply-templates select="*[local-name(.)!='label']"/>
+          <xsl:apply-templates select="*[local-name(.)!='label' and
+                                         not(self::d:indexterm[not(preceding-sibling::*)])]"/>
         </xsl:otherwise>
       </xsl:choose>
       <!-- Uncomment this line to get revhistory output in the question -->
@@ -312,12 +318,17 @@
           </fo:block>
         </xsl:when>
         <xsl:otherwise>
-          <fo:block/>
+          <fo:block>&#xA0;</fo:block>
         </xsl:otherwise>
       </xsl:choose>
+      <!-- include leading indexterms in this part to prevent
+           extra spacing above first para from its space-before -->
+      <xsl:apply-templates mode="leading.indexterms" 
+                           select="child::d:indexterm[not(preceding-sibling::*)]"/>
     </fo:list-item-label>
     <fo:list-item-body start-indent="body-start()">
-      <xsl:apply-templates select="*[local-name(.)!='label' and local-name(.) != 'qandaentry']"/>
+      <xsl:apply-templates select="*[local-name(.)!='label' and local-name(.) != 'qandaentry' and
+                                     not(self::d:indexterm[not(preceding-sibling::*)])]"/>
       <!-- * handle nested answer/qandaentry instances -->
       <!-- * (bug 1509043 from Daniel Leidert) -->
       <xsl:if test="descendant::d:question">


### PR DESCRIPTION
fix bug #108 indexterm before listitem triggers extra blank line. This required processing such leading indexterms inside the list-item-label so they don't emit an empty block at the start of the list-item-body that was triggering the blank line due to space-before of the next element (para).