### PR TITLE
fix issue #113 table entry bottom rowsep not created for morerows entry

### DIFF
--- a/xsl/html/table.xsl
+++ b/xsl/html/table.xsl
@@ -761,7 +761,8 @@
       </xsl:when>
       <!-- not last row with @morerows (thead is not last row) -->
       <xsl:when test="not(ancestor::d:thead) and @morerows and not(@morerows &lt;
-                 count(ancestor-or-self::d:row[1]/following-sibling::d:row))">
+                 ( count(ancestor-or-self::d:row[1]/following-sibling::d:row) +
+                   count(ancestor::d:tgroup/d:tfoot/d:row)) )">
         <xsl:value-of select="0"/>
       </xsl:when>
       <xsl:otherwise>


### PR DESCRIPTION
Fix issue #113 about missing bottom rowsep in table.  The specific issue fixed here was the case where an entry element with @morerows was the last in a tbody, but there existed also a tfoot.  Normally the last row of a table does not generate its own bottom rowsep because the table frame should do that.  But the presence of tfoot was not taken into account and so its rowsep was omitted.  I fixed that calculation to take into account any tfoot rows.