### PR TITLE
fix problem with resourceref to another structure in assemblies

### DIFF
--- a/xsl/assembly/assemble.xsl
+++ b/xsl/assembly/assemble.xsl
@@ -35,6 +35,15 @@
    </xsl:copy>
 </xsl:template>
 
+<!-- process modules and structures encountered in resourceref content -->
+<xsl:template match="d:module" mode="copycontent">
+  <xsl:apply-templates select="."/>
+</xsl:template>
+  
+<xsl:template match="d:structure" mode="copycontent">
+  <xsl:apply-templates select="."/>
+</xsl:template>
+  
 <xsl:template match="processing-instruction('oxygen')"/>
 
 <!-- skip assembly info elements -->
@@ -395,12 +404,21 @@
     
     <xsl:otherwise>
       <xsl:variable name="ref.file.content" select="document($fileref,/)"/>
+        
     
       <!-- selects root or fragment depending on if $fragment is blank -->
-      <xsl:variable name="ref.content"
+      <xsl:variable name="ref.content.element"
         select="$ref.file.content/*[1][$fragment.id = ''] |
                 $ref.file.content/*[1][$fragment.id != '']/
                    descendant-or-self::*[@xml:id = $fragment.id]"/>
+      
+      
+      
+      <xsl:variable name="ref.content.nodes">
+        <xsl:apply-templates select="$ref.content.element" mode="ref.content.nodes"/>
+      </xsl:variable>
+      
+      <xsl:variable name="ref.content" select="exsl:node-set($ref.content.nodes)/*[1]"/>
         
       <xsl:if test="count($ref.content) = 0">
         <xsl:message terminate="yes">
@@ -409,10 +427,12 @@
           <xsl:text>' has no content or is unresolved.</xsl:text>
         </xsl:message>
       </xsl:if>
+      
+      <xsl:variable name="ref.name" select="local-name($ref.content)"/>
 
       <xsl:variable name="element.name">
         <xsl:apply-templates select="." mode="compute.element.name">
-          <xsl:with-param name="ref.name" select="local-name($ref.content)"/>
+          <xsl:with-param name="ref.name" select="$ref.name"/>
         </xsl:apply-templates>
       </xsl:variable>
 
@@ -527,8 +547,17 @@
     </xsl:otherwise>
   </xsl:choose>
 </xsl:template>
-
-<xsl:template name="merge.info">
+  
+<!-- resolve resourceref reference to another structure into content -->  
+<xsl:template match="d:structure" mode="ref.content.nodes">
+  <xsl:apply-templates select="."/>
+</xsl:template>
+  
+<xsl:template match="*" mode="ref.content.nodes">
+  <xsl:copy-of select="."/>
+</xsl:template>
+  
+  <xsl:template name="merge.info">
   <xsl:param name="merge.element" select="NOTANODE"/>
   <xsl:param name="ref.content" select="NOTANODE"/>
   <xsl:param name="omittitles"/> 


### PR DESCRIPTION
Fix problem with an assembly module with resourceref pointing to another structure.  Now it resolves the other structure before final assembly.