### PR TITLE
Bump Lucene version to avoid remote code execution exploit

### DIFF
--- a/maven/docbook-xsl-webhelpindexer/pom.xml
+++ b/maven/docbook-xsl-webhelpindexer/pom.xml
@@ -25,12 +25,12 @@
     <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-core</artifactId>
-      <version>3.0.0</version>
+      <version>7.1.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-analyzers</artifactId>
-      <version>3.0.0</version>
+      <version>7.1.0</version>
     </dependency>
     <dependency>
       <groupId>org.ccil.cowan.tagsoup</groupId>


### PR DESCRIPTION
The tests seem to pass; whether this causes problems for webhelpindexer or not, I don't see how we an leave a remote code exploit in play.
