### PR TITLE
fix bug #133 Citation linking to abbrev should ignore whitespace

### DIFF
--- a/xsl/fo/inline.xsl
+++ b/xsl/fo/inline.xsl
@@ -1227,7 +1227,7 @@
 
 <xsl:template match="d:citation">
   <!-- todo: integrate with bibliography collection -->
-  <xsl:variable name="targets" select="(//d:biblioentry | //d:bibliomixed)[d:abbrev = string(current())]"/>
+  <xsl:variable name="targets" select="(//d:biblioentry | //d:bibliomixed)[normalize-space(d:abbrev) = normalize-space(string(current()))]"/>
   <xsl:variable name="target" select="$targets[1]"/>
 
   <xsl:choose>
@@ -1264,7 +1264,7 @@
 </xsl:template>
 
 <xsl:template match="d:citebiblioid">
-  <xsl:variable name="targets" select="//*[d:biblioid = string(current())]"/>
+  <xsl:variable name="targets" select="//*[normalize-space(d:biblioid) = normalize-space(string(current()))]"/>
   <xsl:variable name="target" select="$targets[1]"/>
 
   <xsl:choose>

--- a/xsl/html/inline.xsl
+++ b/xsl/html/inline.xsl
@@ -1343,7 +1343,7 @@
 
 <xsl:template match="d:citation">
   <!-- todo: integrate with bibliography collection -->
-  <xsl:variable name="targets" select="(//d:biblioentry | //d:bibliomixed)[d:abbrev = string(current())]"/>
+  <xsl:variable name="targets" select="(//d:biblioentry | //d:bibliomixed)[normalize-space(d:abbrev) = normalize-space(string(current()))]"/>
   <xsl:variable name="target" select="$targets[1]"/>
 
   <xsl:choose>
@@ -1381,7 +1381,7 @@
 </xsl:template>
 
 <xsl:template match="d:citebiblioid">
-  <xsl:variable name="targets" select="//*[d:biblioid = string(current())]"/>
+  <xsl:variable name="targets" select="//*[normalize-space(d:biblioid) = normalize-space(string(current()))]"/>
   <xsl:variable name="target" select="$targets[1]"/>
 
   <xsl:choose>


### PR DESCRIPTION
fix bug #133 Citation linking to abbrev should ignore whitespace using normalize-space() function on both strings.