### PR TITLE
Fix insecure tmpdir() creation.

### DIFF
--- a/xsl/epub/bin/dbtoepub
+++ b/xsl/epub/bin/dbtoepub
@@ -62,7 +62,7 @@ if db_files.size == 0
 end
 
 db_files.each {|docbook_file|
-  dir = File.expand_path(File.join(Dir.tmpdir, ".epubtmp#{Time.now.to_f.to_s}"))
+  dir = File.expand_path(File.join(Dir.mktmpdir(), ".epubtmp#{Time.now.to_f.to_s}"))
   FileUtils.mkdir_p(dir)
   e = DocBook::Epub.new(docbook_file, dir, css_file, customization_layer, otf_files)
 

--- a/xsl/epub/bin/spec/epub_realbook_spec.rb
+++ b/xsl/epub/bin/spec/epub_realbook_spec.rb
@@ -20,7 +20,7 @@ TESTDOCSDIR = File.expand_path(File.join(File.dirname(__FILE__), 'files'))
 
 describe DocBook::Epub do
   before(:all) do
-    @tmpdir = File.join(Dir::tmpdir(), "epubspecreal"); Dir.mkdir(@tmpdir) rescue Errno::EEXIST
+    @tmpdir = File.join(Dir.mktmpdir(), "epubspecreal"); Dir.mkdir(@tmpdir) rescue Errno::EEXIST
     @xml_file = Dir["#{TESTDOCSDIR}/orm*.[0-9][0-9][0-9].xml"].sort_by { rand }.first 
     @epub = DocBook::Epub.new(@xml_file, @tmpdir)
     @epub_file = File.join(@tmpdir, File.basename(@xml_file, ".xml") + ".epub")
@@ -28,7 +28,7 @@ describe DocBook::Epub do
 
     FileUtils.copy(@epub_file, "." + File.basename(@xml_file, ".xml") + ".epub") if $DEBUG
 
-    @tmpdir2 = File.join(Dir::tmpdir(), "epubreal"); Dir.mkdir(@tmpdir2) rescue Errno::EEXIST
+    @tmpdir2 = File.join(Dir.mktmpdir(), "epubreal"); Dir.mkdir(@tmpdir2) rescue Errno::EEXIST
     success = system(%Q(unzip -q -o -d "#{@tmpdir2}" "#{@epub_file}"))
     raise "Could not unzip #{epub_file}" unless success
 

--- a/xsl/epub/bin/spec/epub_regressions_spec.rb
+++ b/xsl/epub/bin/spec/epub_regressions_spec.rb
@@ -22,7 +22,7 @@ describe DocBook::Epub do
   before(:all) do
     @filedir = File.expand_path(File.join(File.dirname(__FILE__), 'files'))
     @testdocsdir = File.expand_path(File.join(ENV['repo_dir'], 'testdocs', 'tests'))
-    @tmpdir = File.join(Dir::tmpdir(), "epubregressions"); Dir.mkdir(@tmpdir) rescue Errno::EEXIST
+    @tmpdir = File.join(Dir.mktmpdir(), "epubregressions"); Dir.mkdir(@tmpdir) rescue Errno::EEXIST
   end
 
   it "should not include two <itemref>s to the contents of <part>s in the OPF file" do
@@ -33,7 +33,7 @@ describe DocBook::Epub do
 
     FileUtils.copy(epub_file, "./.t.epub") if $DEBUG
 
-    itemref_tmpdir = File.join(Dir::tmpdir(), "epubitemref"); Dir.mkdir(itemref_tmpdir) rescue Errno::EEXIST
+    itemref_tmpdir = File.join(Dir.mktmpdir(), "epubitemref"); Dir.mkdir(itemref_tmpdir) rescue Errno::EEXIST
     system(%Q(unzip -q -o -d "#{itemref_tmpdir}" "#{epub_file}"))
     opf_file = File.join(itemref_tmpdir, "OEBPS", "content.opf")
     opf = REXML::Document.new(File.new(opf_file))
@@ -44,7 +44,7 @@ describe DocBook::Epub do
 
   it "should preserve content from <dedication> elements" do
     begin
-      tmpdir = File.join(Dir::tmpdir(), "epubdedtest"); Dir.mkdir(tmpdir) rescue Errno::EEXIST
+      tmpdir = File.join(Dir.mktmpdir(), "epubdedtest"); Dir.mkdir(tmpdir) rescue Errno::EEXIST
       
       epub = DocBook::Epub.new(File.join(@testdocsdir, "xref.001.xml"), @tmpdir)
       epubfile = File.join(tmpdir, "regress.ded.epub")
@@ -71,7 +71,7 @@ describe DocBook::Epub do
       css_epubfile = File.join(@tmpdir, "css.epub")
       css_epub.render_to_file(css_epubfile, $DEBUG)
 
-      tmpdir = File.join(Dir::tmpdir(), "epubcssreg"); Dir.mkdir(tmpdir) rescue Errno::EEXIST
+      tmpdir = File.join(Dir.mktmpdir(), "epubcssreg"); Dir.mkdir(tmpdir) rescue Errno::EEXIST
 
       success = system(%Q(unzip -q -d "#{File.expand_path(tmpdir)}" -o "#{css_epubfile}"))
       raise "Could not unzip #{css_epubfile}" unless success
@@ -96,7 +96,7 @@ describe DocBook::Epub do
 
     xhtml_dtd = "DTD XHTML 1.1"
 
-    itemref_tmpdir = File.join(Dir::tmpdir(), "epubitemref"); Dir.mkdir(itemref_tmpdir) rescue Errno::EEXIST
+    itemref_tmpdir = File.join(Dir.mktmpdir(), "epubitemref"); Dir.mkdir(itemref_tmpdir) rescue Errno::EEXIST
     system(%Q(unzip -q -o -d "#{itemref_tmpdir}" "#{epub_file}"))
 
     opf_file = File.join(itemref_tmpdir, "OEBPS", "content.opf")
@@ -155,7 +155,7 @@ describe DocBook::Epub do
   it "should not use a namespace prefix for the container element to help some broken reading systems" do
     filename = "isbn.xml"
     shortname = filename.gsub(/\W/, '')
-    tmpdir = File.join(Dir::tmpdir(), shortname); Dir.mkdir(tmpdir) rescue Errno::EEXIST
+    tmpdir = File.join(Dir.mktmpdir(), shortname); Dir.mkdir(tmpdir) rescue Errno::EEXIST
     epub = DocBook::Epub.new(File.join(@filedir, filename), tmpdir)
     epubfile  = File.join(tmpdir, shortname + ".epub")
     epub.render_to_file(epubfile, $DEBUG)
@@ -192,7 +192,7 @@ describe DocBook::Epub do
 
   it "should not include font style elements like <b> or <i>" do
     begin
-      tmpdir = File.join(Dir::tmpdir(), "epubbtest"); Dir.mkdir(tmpdir) rescue Errno::EEXIST
+      tmpdir = File.join(Dir.mktmpdir(), "epubbtest"); Dir.mkdir(tmpdir) rescue Errno::EEXIST
       
       epub = DocBook::Epub.new(File.join(@testdocsdir, "book.002.xml"), @tmpdir)
       epubfile = File.join(tmpdir, "bcount.epub")
@@ -228,7 +228,7 @@ describe DocBook::Epub do
     ncx_epub.render_to_file(ncx_epubfile, $DEBUG)
     ncx_epubfile.should be_valid_epub  
 
-    ncx_tmpdir = File.join(Dir::tmpdir(), "epubncx"); Dir.mkdir(ncx_tmpdir) rescue Errno::EEXIST
+    ncx_tmpdir = File.join(Dir.mktmpdir(), "epubncx"); Dir.mkdir(ncx_tmpdir) rescue Errno::EEXIST
     system(%Q(unzip -q -o -d "#{ncx_tmpdir}" "#{ncx_epubfile}"))
 
     ncx_file = File.join(ncx_tmpdir, "OEBPS", "toc.ncx")

--- a/xsl/epub/bin/spec/epub_small_smoketest.rb
+++ b/xsl/epub/bin/spec/epub_small_smoketest.rb
@@ -22,7 +22,7 @@ NUMBER_TO_TEST = 15
 describe DocBook::Epub do
 
   before do
-    @tmpdir = File.join(Dir::tmpdir(), "epubspecsmoke"); Dir.mkdir(@tmpdir) rescue Errno::EEXIST
+    @tmpdir = File.join(Dir.mktmpdir(), "epubspecsmoke"); Dir.mkdir(@tmpdir) rescue Errno::EEXIST
   end
 
   Dir["#{TESTDOCSDIR}/*.[0-9][0-9][0-9].xml"].sort_by { rand }[0..(NUMBER_TO_TEST-1)].each do |xml_file|

--- a/xsl/epub/bin/spec/epub_smoketest_spec.rb
+++ b/xsl/epub/bin/spec/epub_smoketest_spec.rb
@@ -22,7 +22,7 @@ TESTDOCSDIR = File.expand_path(File.join(ENV['repo_dir'], 'testdocs', 'tests'))
 describe DocBook::Epub do
 
   before do
-    @tmpdir = File.join(Dir::tmpdir(), "epubspecsmoke"); Dir.mkdir(@tmpdir) rescue Errno::EEXIST
+    @tmpdir = File.join(Dir.mktmpdir(), "epubspecsmoke"); Dir.mkdir(@tmpdir) rescue Errno::EEXIST
   end
 
   # TODO 

--- a/xsl/epub/bin/spec/epub_spec.rb
+++ b/xsl/epub/bin/spec/epub_spec.rb
@@ -23,7 +23,7 @@ describe DocBook::Epub do
     @testdocsdir = File.expand_path(File.join(ENV['repo_dir'], 'testdocs', 'tests'))
     exampledir = File.expand_path(File.join(File.dirname(__FILE__), 'examples'))
     @valid_epub = File.join(exampledir, "AMasqueOfDays.epub")
-    @tmpdir = File.join(Dir::tmpdir(), "epubspec"); Dir.mkdir(@tmpdir) rescue Errno::EEXIST
+    @tmpdir = File.join(Dir.mktmpdir(), "epubspec"); Dir.mkdir(@tmpdir) rescue Errno::EEXIST
 
 
     @simple_bookfile = File.join(@testdocsdir, "book.001.xml")
@@ -168,7 +168,7 @@ describe DocBook::Epub do
 
   it "should not include PDFs in rendered epub files as valid image inclusions" do
     begin
-      tmpdir = File.join(Dir::tmpdir(), "epubinclusiontest"); Dir.mkdir(tmpdir) rescue Errno::EEXIST
+      tmpdir = File.join(Dir.mktmpdir(), "epubinclusiontest"); Dir.mkdir(tmpdir) rescue Errno::EEXIST
 
       success = system(%Q(unzip -q -d "#{File.expand_path(tmpdir)}" -o "#{File.expand_path(@manygraphic_epubfile)}"))
       raise "Could not unzip #{@manygraphic_epubfile}" unless success
@@ -184,7 +184,7 @@ describe DocBook::Epub do
 
   it "should include a CSS link in HTML files when a CSS file has been provided" do
     begin
-      tmpdir = File.join(Dir::tmpdir(), "epubcsshtmltest"); Dir.mkdir(tmpdir) rescue Errno::EEXIST
+      tmpdir = File.join(Dir.mktmpdir(), "epubcsshtmltest"); Dir.mkdir(tmpdir) rescue Errno::EEXIST
 
       success = system(%Q(unzip -q -d "#{File.expand_path(tmpdir)}" -o "#{@css_epubfile}"))
       raise "Could not unzip #{@css_epubfile}" unless success
@@ -200,7 +200,7 @@ describe DocBook::Epub do
 
   it "should include CSS file in .epub when a CSS file has been provided" do
     begin
-      tmpdir = File.join(Dir::tmpdir(), "epubcssfiletest"); Dir.mkdir(tmpdir) rescue Errno::EEXIST
+      tmpdir = File.join(Dir.mktmpdir(), "epubcssfiletest"); Dir.mkdir(tmpdir) rescue Errno::EEXIST
 
       success = system(%Q(unzip -q -d "#{File.expand_path(tmpdir)}" -o "#{@css_epubfile}"))
       raise "Could not unzip #{@css_epubfile}" unless success
@@ -215,7 +215,7 @@ describe DocBook::Epub do
 
   it "should include a reference in the OPF manifest to the provided CSS file" do
     begin
-      tmpdir = File.join(Dir::tmpdir(), "epubcsshtmltest"); Dir.mkdir(tmpdir) rescue Errno::EEXIST
+      tmpdir = File.join(Dir.mktmpdir(), "epubcsshtmltest"); Dir.mkdir(tmpdir) rescue Errno::EEXIST
       
       success = system(%Q(unzip -q -d "#{File.expand_path(tmpdir)}" -o "#{@css_epubfile}"))
       raise "Could not unzip #{@css_epubfile}" unless success
@@ -231,7 +231,7 @@ describe DocBook::Epub do
 
   it "should include a reference in the OPF manifest to the embedded font" do
     begin
-      tmpdir = File.join(Dir::tmpdir(), "epubfontman"); Dir.mkdir(tmpdir) rescue Errno::EEXIST
+      tmpdir = File.join(Dir.mktmpdir(), "epubfontman"); Dir.mkdir(tmpdir) rescue Errno::EEXIST
       
       success = system(%Q(unzip -q -d "#{File.expand_path(tmpdir)}" -o "#{@css_epubfile}"))
       raise "Could not unzip #{@css_epubfile}" unless success
@@ -250,7 +250,7 @@ describe DocBook::Epub do
 
   it "should include the embedded font file in the bundle" do
     begin
-      tmpdir = File.join(Dir::tmpdir(), "epubfontbundle"); Dir.mkdir(tmpdir) rescue Errno::EEXIST
+      tmpdir = File.join(Dir.mktmpdir(), "epubfontbundle"); Dir.mkdir(tmpdir) rescue Errno::EEXIST
       
       success = system(%Q(unzip -q -d "#{File.expand_path(tmpdir)}" -o "#{@css_epubfile}"))
       raise "Could not unzip #{@css_epubfile}" unless success
@@ -271,7 +271,7 @@ describe DocBook::Epub do
 
   it "should include one and only one <h1> in each HTML file in rendered ePub files for <book>s" do
     begin
-      tmpdir = File.join(Dir::tmpdir(), "epubtoctest"); Dir.mkdir(tmpdir) rescue Errno::EEXIST
+      tmpdir = File.join(Dir.mktmpdir(), "epubtoctest"); Dir.mkdir(tmpdir) rescue Errno::EEXIST
       
       epub = DocBook::Epub.new(File.join(@testdocsdir, "book.002.xml"), @tmpdir)
       epubfile = File.join(tmpdir, "h1count.epub")
@@ -295,7 +295,7 @@ describe DocBook::Epub do
 
   it "should include one and only one <h1> in each HTML file in rendered ePub files for <book>s even if they do not have section markup" do
     begin
-      tmpdir = File.join(Dir::tmpdir(), "epubtoctest"); Dir.mkdir(tmpdir) rescue Errno::EEXIST
+      tmpdir = File.join(Dir.mktmpdir(), "epubtoctest"); Dir.mkdir(tmpdir) rescue Errno::EEXIST
       
       epub = DocBook::Epub.new(File.join(@testdocsdir, "book.002.xml"), @tmpdir)
       epubfile = File.join(tmpdir, "h1count2.epub")
@@ -319,7 +319,7 @@ describe DocBook::Epub do
 
   it "should include a TOC link in rendered epub files for <book>s" do
     begin
-      tmpdir = File.join(Dir::tmpdir(), "epubtoctest"); Dir.mkdir(tmpdir) rescue Errno::EEXIST
+      tmpdir = File.join(Dir.mktmpdir(), "epubtoctest"); Dir.mkdir(tmpdir) rescue Errno::EEXIST
       
       epub = DocBook::Epub.new(File.join(@testdocsdir, "book.002.xml"), @tmpdir)
       epubfile = File.join(tmpdir, "toclink.epub")
@@ -341,7 +341,7 @@ describe DocBook::Epub do
 
   it "should allow for the stylesheets to be overridden by a customization layer" do
     begin
-      tmpdir = File.join(Dir::tmpdir(), "epubcusttest"); Dir.mkdir(tmpdir) rescue Errno::EEXIST
+      tmpdir = File.join(Dir.mktmpdir(), "epubcusttest"); Dir.mkdir(tmpdir) rescue Errno::EEXIST
       
       css_file = nil
       customization_layer = File.join(@filedir, "test_cust.xsl")

--- a/xsl/epub/bin/spec/spec_helper.rb
+++ b/xsl/epub/bin/spec/spec_helper.rb
@@ -41,7 +41,7 @@ end
 # Helper Functions
 def opf_lines(filename, filedir)
   shortname = filename.gsub(/\W/, '')
-  tmpdir = File.join(Dir::tmpdir(), shortname); Dir.mkdir(tmpdir) rescue Errno::EEXIST
+  tmpdir = File.join(Dir.mktmpdir(), shortname); Dir.mkdir(tmpdir) rescue Errno::EEXIST
   epub = DocBook::Epub.new(File.join(filedir, filename), tmpdir)
   epubfile  = File.join(tmpdir, shortname + ".epub")
   epub.render_to_file(epubfile, $DEBUG)


### PR DESCRIPTION
See https://ruby-doc.org/stdlib-2.0.0/libdoc/tmpdir/rdoc/Dir.html -
tmpdir returns the same value everytime and as a result the tmpdirs can
be identical or existing.

SECURITY!

Thanks to phaul from #ruby .