### PR TITLE
Clean up trivial param-name mismatch

### DIFF
--- a/xsl/fo/pagesetup.xsl
+++ b/xsl/fo/pagesetup.xsl
@@ -3507,7 +3507,7 @@
 <!-- Customize this template for custom side regions -->
 <xsl:template name="region.inner">
   <xsl:param name="sequence">blank</xsl:param>
-  <xsl:param name="classname">blank</xsl:param>
+  <xsl:param name="pageclass">blank</xsl:param>
 
   <xsl:choose>
     <xsl:when test="$sequence = 'first' or $sequence = 'odd'">
@@ -3544,7 +3544,7 @@
 <!-- Customize this template for custom side regions -->
 <xsl:template name="region.outer">
   <xsl:param name="sequence">blank</xsl:param>
-  <xsl:param name="classname">blank</xsl:param>
+  <xsl:param name="pageclass">blank</xsl:param>
 
   <xsl:choose>
     <xsl:when test="$sequence = 'first' or $sequence = 'odd'">


### PR DESCRIPTION
On the (last) two templates, "region.inner" and "region.outer", the param-name "classname" does not match the with-param name ("pageclass") in the simple-page-masters, set-up in this file, that call these two templates.
I call this a "trivial" clean-up because the param-value is, by default, not actually used in either of these two templates; and because anyone who customizes one or both of these templates, would probably detect the name-mismatch pretty quickly. But still...