### PR TITLE
Remove Travis CI branch limitation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,6 @@ language: java
 jdk:
 - oraclejdk8
 
-branches:
-  only:
-  - master
-  - travis
-  - "/^release.*/"
-  - "/^snapshot.*/"
-  - "/^ndw-test.*/"
-
 env:
   global:
   - CLASSPATH=/usr/share/java/xalan-j2.jar:/usr/share/java/xercesImpl.jar:/usr/share/java/xml-resolver.jar:$(pwd)/.travis


### PR DESCRIPTION
Remove Travis CI branch limitation because it makes the pull request workflows unnecessarily uninviting.

The checks fail because the build JDKs on Travis CI are outdated. I have fix based on this PR available, see https://travis-ci.org/krichter722/xslt10-stylesheets/builds/582306538 for details.