### PR TITLE
Support the filterout element for DocBook assembly structures

### DIFF
--- a/xsl/assembly/assemble.xsl
+++ b/xsl/assembly/assemble.xsl
@@ -17,6 +17,7 @@
 <xsl:param name="docbook.version">5.0</xsl:param>
 <xsl:param name="root.default.renderas">book</xsl:param>
 <xsl:param name="topic.default.renderas">section</xsl:param>
+<xsl:param name="filterout.condition" />
 
 <xsl:param name="output.type" select="''"/>
 <xsl:param name="output.format" select="''"/>
@@ -315,6 +316,10 @@
   <xsl:variable name="renderas">
     <xsl:call-template name="compute.renderas"/>
   </xsl:variable>
+  
+  <xsl:variable name="filterout.condition.value">
+    <xsl:value-of select="@condition" />
+  </xsl:variable>
 
   <xsl:choose>
     <xsl:when test="string-length($renderas) != 0">
@@ -342,6 +347,9 @@
   <xsl:variable name="module" select="."/>
   <xsl:variable name="resourceref" select="@resourceref"/>
   <xsl:variable name="resource" select="key('id', $resourceref)"/>
+  <xsl:variable name="filterout.condition.attribute.value">
+    <xsl:value-of select="d:filterout/@condition" />
+  </xsl:variable>
 
   <xsl:choose>
     <xsl:when test="not($resource)">
@@ -453,6 +461,18 @@
       <xsl:variable name="merge.resource" select="key('id', $merge.resourceref)"/>
 
       <xsl:choose>
+        <xsl:when test="$filterout.condition = $filterout.condition.attribute.value">
+          <!-- Do not render a module if it includes a filterout 
+          element with its condition attribute set to a string that 
+          matches the filterout.condition parameter. -->
+          <xsl:message>
+            <xsl:text>INFO: omitting a module because </xsl:text>
+            <xsl:value-of select="$filterout.condition" />
+            <xsl:text> is set to </xsl:text>
+            <xsl:value-of select="$filterout.condition.attribute.value" />
+            <xsl:text>.</xsl:text>
+          </xsl:message>
+        </xsl:when>
         <xsl:when test="$contentonly.property = 'true' or 
                         $contentonly.property = 'yes' or
                         $contentonly.property = '1'">
@@ -733,13 +753,6 @@
 </xsl:template>
 
 <xsl:template match="d:filterin">
-  <xsl:message>
-    <xsl:text>WARNING: the &lt;filterin&gt; element is not currently </xsl:text>
-    <xsl:text>supported by this stylesheet.</xsl:text>
-  </xsl:message>
-</xsl:template>
-
-<xsl:template match="d:filterout">
   <xsl:message>
     <xsl:text>WARNING: the &lt;filterin&gt; element is not currently </xsl:text>
     <xsl:text>supported by this stylesheet.</xsl:text>


### PR DESCRIPTION
This PR adds support for the `filterout` element in a DocBook assembly `structure` element.

https://github.com/docbook/xslt10-stylesheets/issues/140