### PR TITLE
Add bgcolor to the attributes that get folded into a style attribute.

### DIFF
--- a/xsl/xhtml5/html5-element-mods.xsl
+++ b/xsl/xhtml5/html5-element-mods.xsl
@@ -336,7 +336,7 @@
 
 <!-- HTML5: converts obsolete HTML attributes to CSS styles -->
 <xsl:template match="*" mode="convert.to.style">
-
+ 
   <xsl:variable name="element" select="local-name(.)"/>
 
   <xsl:variable name="style.from.atts">
@@ -397,6 +397,12 @@
           <xsl:text>px</xsl:text>
           <xsl:text>; </xsl:text>
         </xsl:when>
+
+        <xsl:when test="local-name() = 'bgcolor'">
+          <xsl:text>background-color: </xsl:text>
+          <xsl:value-of select="."/>
+         <xsl:text>; </xsl:text>
+        </xsl:when>
       </xsl:choose>
     </xsl:for-each>
   </xsl:variable>
@@ -426,6 +432,7 @@
         <xsl:when test="local-name(.) = 'border'"/>
         <xsl:when test="local-name(.) = 'cellspacing'"/>
         <xsl:when test="local-name(.) = 'cellpadding'"/>
+        <xsl:when test="local-name(.) = 'bgcolor'"/>
         <xsl:when test="local-name(.) = 'style'"/>
         <xsl:when test="local-name(.) = 'align'"/>
         <xsl:when test="local-name(.) = 'valign'"/>


### PR DESCRIPTION
The bgcolor attribute is disallowed in html5. This update changes the bgcolor attribute into a value added to the style attribute of the parent element.