### PR TITLE
fix bug #147 precedence does not apply to side regions

### DIFF
--- a/xsl/fo/pagesetup.xsl
+++ b/xsl/fo/pagesetup.xsl
@@ -36,21 +36,6 @@
   <xsl:value-of select="$symbol.font.family"/>
 </xsl:param>
 
-<!-- These are internal parameters are for the individual precedence attributes -->
-<xsl:param name="region.start.precedence">
-  <xsl:choose>
-    <xsl:when test="$side.region.precedence = 'true'">true</xsl:when>
-    <xsl:otherwise>false</xsl:otherwise>
-  </xsl:choose>
-</xsl:param>
-
-<xsl:param name="region.end.precedence">
-  <xsl:choose>
-    <xsl:when test="$side.region.precedence = 'true'">true</xsl:when>
-    <xsl:otherwise>false</xsl:otherwise>
-  </xsl:choose>
-</xsl:param>
-
 <xsl:param name="region.before.precedence">
   <xsl:choose>
     <xsl:when test="$side.region.precedence = 'true'">false</xsl:when>
@@ -3516,9 +3501,6 @@
           <xsl:text>xsl-region-inner-</xsl:text>
           <xsl:value-of select="$sequence"/>
         </xsl:attribute>
-        <xsl:attribute name="precedence">
-          <xsl:value-of select="$region.start.precedence"/>
-        </xsl:attribute>
         <xsl:attribute name="extent">
           <xsl:value-of select="$region.inner.extent"/>
         </xsl:attribute>
@@ -3529,9 +3511,6 @@
         <xsl:attribute name="region-name">
           <xsl:text>xsl-region-inner-</xsl:text>
           <xsl:value-of select="$sequence"/>
-        </xsl:attribute>
-        <xsl:attribute name="precedence">
-          <xsl:value-of select="$region.end.precedence"/>
         </xsl:attribute>
         <xsl:attribute name="extent">
           <xsl:value-of select="$region.inner.extent"/>
@@ -3553,9 +3532,6 @@
           <xsl:text>xsl-region-outer-</xsl:text>
           <xsl:value-of select="$sequence"/>
         </xsl:attribute>
-        <xsl:attribute name="precedence">
-          <xsl:value-of select="$region.start.precedence"/>
-        </xsl:attribute>
         <xsl:attribute name="extent">
           <xsl:value-of select="$region.outer.extent"/>
         </xsl:attribute>
@@ -3566,9 +3542,6 @@
         <xsl:attribute name="region-name">
           <xsl:text>xsl-region-outer-</xsl:text>
           <xsl:value-of select="$sequence"/>
-        </xsl:attribute>
-        <xsl:attribute name="precedence">
-          <xsl:value-of select="$region.end.precedence"/>
         </xsl:attribute>
         <xsl:attribute name="extent">
           <xsl:value-of select="$region.outer.extent"/>

--- a/xsl/params/side.region.precedence.xml
+++ b/xsl/params/side.region.precedence.xml
@@ -37,15 +37,13 @@ Any value other than <literal>true</literal> or
 <literal>false</literal> is taken to be <literal>false</literal>.</para>
 
 <para>If you need to set precedence separately for
-individual regions, then you can set four
+individual regions, then you can set two
 parameters that are normally internal to the stylesheet.
-These four parameters are normally set based
+These two parameters are normally set based
 on the value from <parameter>side.region.precedence</parameter>:</para>
 
 <programlisting>region.before.precedence
-region.after.precedence
-region.start.precedence
-region.end.precedence</programlisting>
+region.after.precedence</programlisting>
 
 <para>See also
 <parameter>region.inner.extent</parameter>,


### PR DESCRIPTION
fix bug #147 by removing internal parameters region.start.precedence and region.end.precedence which were applied to the side regions, but the side regions do not accept the precedence property.  I also removed mention of those params in the documentation for the parameter 'side.region.precedence', which actually sets the precedence property on the before and after regions.