### PR TITLE
fix issue #138 vertical alignment of list items

### DIFF
--- a/xsl/params/list.item.spacing.xml
+++ b/xsl/params/list.item.spacing.xml
@@ -18,10 +18,13 @@
   <xsl:attribute name="space-before.optimum">1em</xsl:attribute>
   <xsl:attribute name="space-before.minimum">0.8em</xsl:attribute>
   <xsl:attribute name="space-before.maximum">1.2em</xsl:attribute>
+  <xsl:attribute name="relative-align">baseline</xsl:attribute>
 </xsl:attribute-set></src:fragment>
 </refsynopsisdiv>
 <refsection><info><title>Description</title></info>
 <para>Specify what spacing you want before (and optionally after) each list item.</para>
+<para>The setting for <tag>relative-align</tag> ensures the text aligns vertically with the list mark
+even if an inline image is in the text.</para>
 <para>See also <parameter>list.block.spacing</parameter>, which sets
 the spacing before and after an entire list.</para>
 </refsection>


### PR DESCRIPTION
Set the default value of relative-align on list items to 'baseline' so that any inline images in the text don't push the text down relative to the list item mark.