### PR TITLE
Extension function instead of Saxon6 <saxon:script>

### DIFF
--- a/xsl/highlighting/common.xsl
+++ b/xsl/highlighting/common.xsl
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 		xmlns:d="http://docbook.org/ns/docbook"
-		xmlns:s6hl="http://net.sf.xslthl/ConnectorSaxon6" 
+		xmlns:s6hl="java:net.sf.xslthl.ConnectorSaxon6" 
 		xmlns:sbhl="http://net.sf.xslthl/ConnectorSaxonB" 
 		xmlns:xhl="http://net.sf.xslthl/ConnectorXalan"
 		xmlns:saxon6="http://icl.com/saxon" 
@@ -24,9 +24,6 @@
 <xalan:component prefix="xhl" functions="highlight"> 
   <xalan:script lang="javaclass" src="xalan://net.sf.xslthl.ConnectorXalan" /> 
 </xalan:component> 
-
-<!-- for saxon 6 -->
-<saxon6:script implements-prefix="s6hl" language="java" src="java:net.sf.xslthl.ConnectorSaxon6" />
 
 <!-- for saxon 8.5 and later -->
 <saxonb:script implements-prefix="sbhl" language="java" src="java:net.sf.xslthl.ConnectorSaxonB" />


### PR DESCRIPTION
`<saxon:script>` is a synonym of `<xsl:script>`. The advice for `<xsl:script>` is that "it's simpler to avoid using this element altogether, and instead to use a namespace URI that identifies the extension function directly". (http://saxon.sourceforge.net/saxon6.5.5/xsl-elements.html#xsl:script)

My real reason for the change is that `function-available('s6hl:highlight')` now actually works, instead of the transformation failing at the `<saxon:script>` when the extension is not available.