### PR TITLE
Discard empty keywords, de-dupe and sort remainder

### DIFF
--- a/xsl/fo/axf.xsl
+++ b/xsl/fo/axf.xsl
@@ -6,6 +6,10 @@
                 xmlns:axf="http://www.antennahouse.com/names/XSL/Extensions"
                 version='1.0'>
 
+<xsl:key name="keywords"
+         match="keyword[normalize-space(.) != '']"
+         use="normalize-space(.)" />
+
 <xsl:template name="axf-document-information">
 
     <xsl:variable name="authors" select="(//d:author|//d:editor|
@@ -51,11 +55,14 @@
     <axf:document-info name="title" value="{normalize-space($title)}"/>
     <axf:document-info name="displaydoctitle" value="true"/>
 
-    <xsl:if test="//d:keyword">
+    <xsl:if test="//keyword">
       <xsl:element name="axf:document-info">
         <xsl:attribute name="name">keywords</xsl:attribute>
         <xsl:attribute name="value">
-          <xsl:for-each select="//d:keyword">
+          <xsl:for-each
+              select="//keyword[normalize-space(.) != '']
+                               [count(. | key('keywords', normalize-space(.))[1]) = 1]">
+            <xsl:sort select="normalize-space(.)"/>
             <xsl:value-of select="normalize-space(.)"/>
             <xsl:if test="position() != last()">
               <xsl:text>, </xsl:text>

--- a/xsl/fo/axf.xsl
+++ b/xsl/fo/axf.xsl
@@ -7,7 +7,7 @@
                 version='1.0'>
 
 <xsl:key name="keywords"
-         match="keyword[normalize-space(.) != '']"
+         match="d:keyword[normalize-space(.) != '']"
          use="normalize-space(.)" />
 
 <xsl:template name="axf-document-information">
@@ -55,13 +55,13 @@
     <axf:document-info name="title" value="{normalize-space($title)}"/>
     <axf:document-info name="displaydoctitle" value="true"/>
 
-    <xsl:if test="//keyword">
+    <xsl:if test="//d:keyword">
       <xsl:element name="axf:document-info">
         <xsl:attribute name="name">keywords</xsl:attribute>
         <xsl:attribute name="value">
           <xsl:for-each
-              select="//keyword[normalize-space(.) != '']
-                               [count(. | key('keywords', normalize-space(.))[1]) = 1]">
+              select="//d:keyword[normalize-space(.) != '']
+                                 [count(. | key('keywords', normalize-space(.))[1]) = 1]">
             <xsl:sort select="normalize-space(.)"/>
             <xsl:value-of select="normalize-space(.)"/>
             <xsl:if test="position() != last()">


### PR DESCRIPTION
Also, stylesheet was conflicted about whether it was working with `d:keyword` or `keyword`.