### PR TITLE
Add 'user-axf-document-information' named template

### DIFF
--- a/xsl/fo/axf.xsl
+++ b/xsl/fo/axf.xsl
@@ -79,7 +79,11 @@
       </xsl:element>
     </xsl:if>
 
+    <xsl:call-template name="user-axf-document-information" />
+
 </xsl:template>
+
+<xsl:template name="user-axf-document-information" />
 
 <!-- These properties are added to fo:simple-page-master -->
 <xsl:template name="axf-page-master-properties">


### PR DESCRIPTION
Allow user to add additional `<axf:document-info>`, e.g., to set display mode in PDF output:

````
<xsl:template name="user-axf-document-information">
  <axf:document-info name="pagelayout" value="TwoPageRight" />
</xsl:template>
````

See https://www.antennahouse.com/product/ahf66/ahf-ext.html#document-info.