### PR TITLE
keyword metadata now removes duplicates and is sorted

### DIFF
--- a/xsl/fo/axf.xsl
+++ b/xsl/fo/axf.xsl
@@ -6,10 +6,6 @@
                 xmlns:axf="http://www.antennahouse.com/names/XSL/Extensions"
                 version='1.0'>
 
-<xsl:key name="keywords"
-         match="d:keyword[normalize-space(.) != '']"
-         use="normalize-space(.)" />
-
 <xsl:template name="axf-document-information">
 
     <xsl:variable name="authors" select="(//d:author|//d:editor|

--- a/xsl/fo/docbook.xsl
+++ b/xsl/fo/docbook.xsl
@@ -91,6 +91,10 @@
 
 <xsl:key name="id" match="*" use="@id|@xml:id"/>
 
+<xsl:key name="keywords"
+         match="d:keyword[normalize-space(.) != '']"
+         use="normalize-space(.)" />
+
 <!-- ==================================================================== -->
 
 <xsl:template match="*">

--- a/xsl/fo/fop1.xsl
+++ b/xsl/fo/fop1.xsl
@@ -202,7 +202,10 @@
           <!-- Keywords -->
           <xsl:if test="//d:keyword">
             <pdf:Keywords>
-              <xsl:for-each select="//d:keyword">
+              <xsl:for-each
+                  select="//d:keyword[normalize-space(.) != '']
+                                     [count(. | key('keywords', normalize-space(.))[1]) = 1]">
+                <xsl:sort select="normalize-space(.)"/>
                 <xsl:value-of select="normalize-space(.)"/>
                 <xsl:if test="position() != last()">
                   <xsl:text>, </xsl:text>

--- a/xsl/fo/xep.xsl
+++ b/xsl/fo/xep.xsl
@@ -77,7 +77,10 @@
       <xsl:element name="rx:meta-field">
         <xsl:attribute name="name">keywords</xsl:attribute>
         <xsl:attribute name="value">
-          <xsl:for-each select="//d:keyword">
+          <xsl:for-each
+              select="//d:keyword[normalize-space(.) != '']
+                                 [count(. | key('keywords', normalize-space(.))[1]) = 1]">
+            <xsl:sort select="normalize-space(.)"/>
             <xsl:value-of select="normalize-space(.)"/>
             <xsl:if test="position() != last()">
               <xsl:text>, </xsl:text>


### PR DESCRIPTION
Fix for issue #187 to sort and remove duplicates of keywords in PDF metadata.  Applied the earlier fix to axf.xsl to both fop1.xsl and xep.xsl.