### PR TITLE
fix bug #192 incorrect langcodes for locale files

### DIFF
--- a/gentext/locale/cy.xml
+++ b/gentext/locale/cy.xml
@@ -569,7 +569,7 @@
 </context>
 
 <context name="htmlhelp">
-<template name="langcode">0x0409 Welsh (UNITED KINGDOM)</template>
+<template name="langcode">0x0452 Welsh (UNITED KINGDOM)</template>
 </context>
 
 <letters>

--- a/gentext/locale/lv.xml
+++ b/gentext/locale/lv.xml
@@ -592,7 +592,7 @@
 </context>
 
 <context name="htmlhelp">
-<template name="langcode">0x0427 Latvian</template>
+<template name="langcode">0x0426 Latvian</template>
 </context>
 
 <context name="index">

--- a/gentext/locale/ta.xml
+++ b/gentext/locale/ta.xml
@@ -599,7 +599,7 @@
 </context>
 
 <context name="htmlhelp">
-<template name="langcode">0x0049 Tamil</template>
+<template name="langcode">0x0449 Tamil</template>
 </context>
 
 <context name="index">

--- a/gentext/locale/tl.xml
+++ b/gentext/locale/tl.xml
@@ -569,7 +569,7 @@
 </context>
 
 <context name="htmlhelp">
-<template name="langcode">0x0409 Tagalog (PHILIPPINES)</template>
+<template name="langcode">0x0464 Tagalog (PHILIPPINES)</template>
 </context>
 
 <letters>


### PR DESCRIPTION
Entered correct langcodes for htmlhelp for cy.xml (Welsh), lv.xml (Latvian), ta.xml (Tamil), and tl.xml (Tagalog) to fix issue #192