### PR TITLE
fix issue #227 to turn off relative-align in header and footer

### DIFF
--- a/xsl/fo/pagesetup.xsl
+++ b/xsl/fo/pagesetup.xsl
@@ -2734,9 +2734,12 @@
     </xsl:when>
   </xsl:choose>
 
+  <!-- turn this off because relative-align is ignored unless display-align = auto -->
+  <!--
   <xsl:if test="$fop.extensions = 0">
     <xsl:attribute name="relative-align">baseline</xsl:attribute>
   </xsl:if>
+  -->
 </xsl:template>
 
 <!-- controls whether the header content assembled in
@@ -3123,9 +3126,12 @@
     </xsl:when>
   </xsl:choose>
 
+  <!-- turn this off because relative-align is ignored unless display-align = auto -->
+  <!--
   <xsl:if test="$fop.extensions = 0">
     <xsl:attribute name="relative-align">baseline</xsl:attribute>
   </xsl:if>
+  -->
 </xsl:template>
 
 <!-- controls whether the footer content assembled in


### PR DESCRIPTION
The XSL spec says setting relative-align to baseline has no effect unless display-align="auto" as reported in issue #227.  The header and footer cell property templates was trying to set relative-align, so I commented out those lines to turn that off.  I left the code commented out in case someone needs to restore it for their setup.