### PR TITLE
fix issue #228 so @format test is not case sensitive

### DIFF
--- a/xsl/html/graphics.xsl
+++ b/xsl/html/graphics.xsl
@@ -289,7 +289,7 @@
     <!-- This funny compound test works around a bug in XSLTC -->
     <xsl:choose>
       <xsl:when test="$use.extensions != 0 and $graphicsize.extension != 0
-                      and not(@format='SVG')">
+                      and not(@format='SVG' or @format = 'svg')">
         <xsl:choose>
           <xsl:when test="function-available('simg:getWidth')">
             <xsl:value-of select="simg:getWidth(simg:new($filename.for.graphicsize),
@@ -325,7 +325,7 @@
     <!-- This funny compound test works around a bug in XSLTC -->
     <xsl:choose>
       <xsl:when test="$use.extensions != 0 and $graphicsize.extension != 0
-                      and not(@format='SVG')">
+                      and not(@format='SVG' or @format = 'svg')">
         <xsl:choose>
           <xsl:when test="function-available('simg:getDepth')">
             <xsl:value-of select="simg:getDepth(simg:new($filename.for.graphicsize),
@@ -540,7 +540,7 @@ valign: <xsl:value-of select="@valign"/></xsl:message>
 
   <xsl:variable name="img">
     <xsl:choose>
-      <xsl:when test="@format = 'SVG'">
+      <xsl:when test="@format = 'SVG' or @format = 'svg'">
         <object type="image/svg+xml">
 	  <xsl:attribute name="data">
 	    <xsl:choose>


### PR DESCRIPTION
The @format test should accept 'svg' or 'SVG' values, so I changed html/graphics.xsl to allow that.