### PR TITLE
Add .mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,8 @@
+Adam Di Carlo <a.p.dicarlo@gmail.com> <adicarlo@users.sourceforge.net>
+Cedric Pronzato <mimilowns@gmail.com> <mimil@users.sourceforge.net>
+Gábor Kövesdán <gabor.kovesdan@gmail.com> <gabor@kovesdan.org>
+Keith Fahlgren <abdelazer@gmail.com> <abdelazer@users.sourceforge.net>
+Martijn van Beers <mail_dev@martijn.at> <lotr@users.sourceforge.net>
+Michael[tm] Smith <mike@w3.org> <xmldoc@users.sourceforge.net>
+mzjn <mzjnse@gmail.com> <mj@johanneberg.com>
+Steve Ball <Steve.Ball@explain.com.au> <balls@users.sourceforge.net>


### PR DESCRIPTION
In the interest of having the https://github.com/docbook/xslt10-stylesheets/graphs/contributors graph for this repo show a more-complete record of contributions, this change adds a `.mailmap` file that maps old `users.sourceforge.net` e-mail addresses (mostly) for some contributors to the current e-mail addresses with which they’ve committed to GitHub repos.

The effect of this is to make GitHub recognize the users such that they show up in Contributors graph.

This isn’t meant to be complete but instead is just limited to people who have at least 20 commits in the commit history for the repo.

@adicarlo, @mimil, @gaborbsd, @abdelazer, @martijnvanbeers, @mzjn, @ballsteve — if any of you don’t actually want to be added here, let me know, and I’ll drop your info from the patch.

Note that all the e-mail addresses added here are already exposed through commit histories for other GitHub repos (which is how I found them).