### PR TITLE
Fix #254: Pass structure/@xml:lang to result doc

### DIFF
--- a/xsl/assembly/assemble.xsl
+++ b/xsl/assembly/assemble.xsl
@@ -134,7 +134,7 @@
     <xsl:attribute name="version">
       <xsl:value-of select="$docbook.version"/>
     </xsl:attribute>
-    <xsl:copy-of select="@xml:id"/>
+    <xsl:copy-of select="@xml:id|@xml:lang"/>
 
     <!-- get any merge resource element before changing context -->
     <xsl:variable name="merge.resourceref" select="d:merge[1]/@resourceref"/>


### PR DESCRIPTION
This PR fixes #254.

Pass `xml:lang` attribute on `<structure>` (without `@resourceref`) to the root element of the result document.

Without this fix, an author cannot set the language of the result document.

@bobstayton: This should be easy to review, it's just one line. :wink: 

----

If we want to go the extra mile, we could use the `xml:lang` attribute from `<assembly>`, if there is none on `<structure>`. Should we take that into account? If yes, the line should look like this:

```xml
<xsl:copy-of select="@xml:id|(@xml:lang|/d:assembly/@xml:lang)[last()]"/>
```