### PR TITLE
Add both http and https entries to catalog.xml.

### DIFF
--- a/releasetools/make-catalog.xsl
+++ b/releasetools/make-catalog.xsl
@@ -15,7 +15,7 @@
 <xsl:param name="BRANCH">
   <xsl:value-of select="string(document('VERSION.xsl')//fm:Branch[1])"/>
 </xsl:param>
-<xsl:param name="URI_BASE">https://cdn.docbook.org/release</xsl:param>
+<xsl:param name="URI_BASE">cdn.docbook.org/release</xsl:param>
 <xsl:param name="DISTRO"/>
 <xsl:param name="SUBDIR">current</xsl:param>
 
@@ -28,17 +28,28 @@
   <xsl:text> </xsl:text>
 </xsl:param>
 
+<xsl:template name="generate-entries"
+              xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+  <xsl:param name="scheme"/>
+  <rewriteURI uriStartString="{$scheme}://{$URI_BASE}/{$DISTRO}/{$SUBDIR}/" rewritePrefix="./"/>
+  <rewriteSystem systemIdStartString="{$scheme}://{$URI_BASE}/{$DISTRO}/{$SUBDIR}/" rewritePrefix="./"/>
+
+  <rewriteURI uriStartString="{$scheme}://{$URI_BASE}/{$DISTRO}/{$VERSION}/" rewritePrefix="./"/>
+  <rewriteSystem systemIdStartString="{$scheme}://{$URI_BASE}/{$DISTRO}/{$VERSION}/" rewritePrefix="./"/>
+</xsl:template>
+
 <xsl:template match="/">
 
   <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <xsl:text>&#10;</xsl:text>
     <xsl:comment><xsl:value-of select="$COMMENT"/></xsl:comment>
 
-    <rewriteURI uriStartString="{$URI_BASE}/{$DISTRO}/{$SUBDIR}/" rewritePrefix="./"/>
-    <rewriteSystem systemIdStartString="{$URI_BASE}/{$DISTRO}/{$SUBDIR}/" rewritePrefix="./"/>
-
-    <rewriteURI uriStartString="{$URI_BASE}/{$DISTRO}/{$VERSION}/" rewritePrefix="./"/>
-    <rewriteSystem systemIdStartString="{$URI_BASE}/{$DISTRO}/{$VERSION}/" rewritePrefix="./"/>
+    <xsl:call-template name="generate-entries">
+      <xsl:with-param name="scheme">http</xsl:with-param>
+    </xsl:call-template>
+    <xsl:call-template name="generate-entries">
+      <xsl:with-param name="scheme">https</xsl:with-param>
+    </xsl:call-template>
   </catalog>
   <xsl:text>&#10;</xsl:text>
 

--- a/xsl/Makefile
+++ b/xsl/Makefile
@@ -63,7 +63,8 @@ DISTRIB_PACKAGES = doc
 
 # list of pathname+URIs to test for catalog support
 URILIST = \
-.\ https://cdn.docbook.org/release/xsl/current/
+.\ https://cdn.docbook.org/release/xsl/current/ \
+.\ http://cdn.docbook.org/release/xsl/current/
 
 DIRS=common lib html fo manpages htmlhelp javahelp eclipse roundtrip slides website extensions xhtml xhtml-1_1 webhelp xhtml5 epub3
 


### PR DESCRIPTION
Commit e5e4487a810037c38896a19b11752987c9a25b23 replaced http:// with https:// but this breaks XML catalog lookups for documents that use the non-https URI.
Re-add http:// entries in the catalog for compatibility.